### PR TITLE
Add weekly summary in Gym

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.1.6",
+        "@react-native-async-storage/async-storage": "^1.20.2",
         "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.10",
         "@react-three/drei": "^10.2.0",
@@ -2442,6 +2443,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -5423,6 +5436,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -6216,6 +6238,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "^4.11.1",
-    "three": "^0.166.1"
+    "three": "^0.166.1",
+    "@react-native-async-storage/async-storage": "^1.20.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   StyleSheet,
@@ -10,6 +10,8 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFocusEffect } from '@react-navigation/native';
 
 export default function GymScreen() {
   const [workouts, setWorkouts] = useState([]);
@@ -25,6 +27,85 @@ export default function GymScreen() {
     weight: '',
   });
   const [editingExerciseIdx, setEditingExerciseIdx] = useState(null);
+  const [showSummaryModal, setShowSummaryModal] = useState(false);
+  const [weeklySummary, setWeeklySummary] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      const stored = await AsyncStorage.getItem('workouts');
+      if (stored) {
+        try {
+          setWorkouts(JSON.parse(stored));
+        } catch {}
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('workouts', JSON.stringify(workouts));
+  }, [workouts]);
+
+  const getStartOfWeek = date => {
+    const d = new Date(date);
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1); // adjust when day is sunday
+    d.setDate(diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  };
+
+  const computeSummary = weekWorkouts => {
+    let totalSets = 0;
+    let totalWeight = 0;
+    const exerciseCounts = {};
+
+    weekWorkouts.forEach(w => {
+      w.exercises.forEach(ex => {
+        const sets = parseInt(ex.sets) || 0;
+        const reps = parseInt(ex.reps) || 0;
+        const weight = parseFloat(ex.weight) || 0;
+        totalSets += sets;
+        totalWeight += sets * reps * weight;
+        exerciseCounts[ex.name] = (exerciseCounts[ex.name] || 0) + sets;
+      });
+    });
+
+    let favoriteExercise = null;
+    let maxSets = 0;
+    Object.entries(exerciseCounts).forEach(([name, sets]) => {
+      if (sets > maxSets) {
+        maxSets = sets;
+        favoriteExercise = name;
+      }
+    });
+
+    return { totalSets, totalWeight, favoriteExercise };
+  };
+
+  const checkWeeklySummary = async () => {
+    const now = new Date();
+    const startOfThisWeek = getStartOfWeek(now);
+    const lastShown = await AsyncStorage.getItem('lastSummaryShown');
+    if (!lastShown || parseInt(lastShown) < startOfThisWeek.getTime()) {
+      const prevWeekStart = new Date(startOfThisWeek);
+      prevWeekStart.setDate(prevWeekStart.getDate() - 7);
+      const weekWorkouts = workouts.filter(w => {
+        const dt = new Date(w.date);
+        return dt >= prevWeekStart && dt < startOfThisWeek;
+      });
+      if (weekWorkouts.length) {
+        setWeeklySummary(computeSummary(weekWorkouts));
+        setShowSummaryModal(true);
+      }
+      await AsyncStorage.setItem('lastSummaryShown', String(now.getTime()));
+    }
+  };
+
+  useFocusEffect(
+    React.useCallback(() => {
+      checkWeeklySummary();
+    }, [workouts])
+  );
 
   const openNewWorkout = () => {
     setWorkoutName('');
@@ -45,7 +126,10 @@ export default function GymScreen() {
         w.map((wk, i) => (i === currentWorkoutIdx ? { ...wk, name: workoutName } : wk))
       );
     } else {
-      setWorkouts(w => [...w, { name: workoutName, exercises: [] }]);
+      setWorkouts(w => [
+        ...w,
+        { name: workoutName, exercises: [], date: new Date().toISOString() },
+      ]);
     }
     setShowWorkoutModal(false);
   };
@@ -116,6 +200,28 @@ export default function GymScreen() {
       <TouchableOpacity style={styles.addWorkoutBtn} onPress={openNewWorkout}>
         <Ionicons name="add" size={32} color="#fff" />
       </TouchableOpacity>
+
+      {/* Summary Modal */}
+      <Modal visible={showSummaryModal} transparent animationType="fade">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>Weekly Summary</Text>
+            {weeklySummary && (
+              <>
+                <Text style={styles.summaryText}>Total Sets: {weeklySummary.totalSets}</Text>
+                <Text style={styles.summaryText}>Total Weight: {weeklySummary.totalWeight}</Text>
+                <Text style={styles.summaryText}>Favorite Exercise: {weeklySummary.favoriteExercise}</Text>
+              </>
+            )}
+            <TouchableOpacity
+              style={styles.modalButton}
+              onPress={() => setShowSummaryModal(false)}
+            >
+              <Text style={styles.modalButtonText}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
 
       {/* Workout Modal */}
       <Modal visible={showWorkoutModal} transparent animationType="fade">
@@ -276,6 +382,11 @@ const styles = StyleSheet.create({
     padding: 8,
     marginBottom: 12,
     color: '#222',
+  },
+  summaryText: {
+    color: '#222',
+    marginBottom: 4,
+    textAlign: 'center',
   },
   modalButton: {
     backgroundColor: '#007AFF',


### PR DESCRIPTION
## Summary
- install AsyncStorage for persistence
- show weekly workout summary on first login of week
- save workouts with date in Gym screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fa2da4ba88328a7777e3c58de5fd4