### PR TITLE
Fix sprite clicks and gym background

### DIFF
--- a/src/screens/GymGameScreen.js
+++ b/src/screens/GymGameScreen.js
@@ -65,12 +65,14 @@ export default function GymGameScreen() {
 
   const entities = {
     physics: { engine: engine.current, world },
-    character: { body: characterBody, renderer: <Character body={characterBody} onPress={showStats} /> },
+    character: { body: characterBody },
   };
 
   return (
     <SafeAreaView style={styles.container}>
-      <GameEngine style={styles.engine} systems={[Physics]} entities={entities} />
+      <GameEngine style={styles.engine} systems={[Physics]} entities={entities}>
+        <Character body={characterBody} onPress={showStats} />
+      </GameEngine>
       <View style={styles.buttonContainer}>
         <Button title="+ Set" onPress={addSet} />
       </View>

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -101,10 +101,7 @@ export default function GymScreen() {
 
   const entities = {
     physics: { engine: engine.current, world },
-    character: {
-      body: characterBody,
-      renderer: <Character body={characterBody} onPress={showStats} />,
-    },
+    character: { body: characterBody },
   };
 
   useEffect(() => {
@@ -249,7 +246,9 @@ export default function GymScreen() {
     >
       <SafeAreaView style={styles.container}>
       <View style={styles.gameContainer}>
-        <GameEngine systems={[Physics]} entities={entities} style={styles.engine} />
+        <GameEngine systems={[Physics]} entities={entities} style={styles.engine}>
+          <Character body={characterBody} onPress={showStats} />
+        </GameEngine>
         <View style={styles.buttonContainer}>
           <Button title="+ Set" onPress={addSet} />
         </View>
@@ -426,7 +425,7 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
-    backgroundColor: '#000',
+    backgroundColor: 'transparent',
   },
   contentContainer: {
     padding: 16,


### PR DESCRIPTION
## Summary
- allow character presses to work inside GameEngine
- use transparent container background to show gym image
- add sprite as GameEngine child on both screens

## Testing
- `npm install`
- `CI=1 npx expo start --dev-client --offline` *(fails: waiting for connection)*

------
https://chatgpt.com/codex/tasks/task_e_6850f511f6d08328b478412431fbe6df