### PR TITLE
Use sprite image as profile picture

### DIFF
--- a/src/components/ProfileModal.js
+++ b/src/components/ProfileModal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, Modal, TouchableOpacity, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, Modal, TouchableOpacity, Dimensions, Image } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 export default function ProfileModal({ isVisible, onClose }) {
@@ -19,7 +19,7 @@ export default function ProfileModal({ isVisible, onClose }) {
 
           {/* Avatar */}
           <View style={styles.avatarContainer}>
-            <Text style={styles.avatarEmoji}>😊</Text>
+            <Image source={require('../../assets/AppSprite.png')} style={styles.avatarImage} />
           </View>
 
           {/* User Info */}
@@ -92,9 +92,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: 16,
+    overflow: 'hidden',
   },
-  avatarEmoji: {
-    fontSize: 50,
+  avatarImage: {
+    width: '100%',
+    height: '100%',
   },
   username: {
     fontSize: 24,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -32,7 +32,7 @@ export default function ProfileScreen() {
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Profile Info */}
         <View style={styles.profileInfo}>
-          <Image source={require('../explore_bg.png')} style={styles.avatar} />
+          <Image source={require('../../assets/AppSprite.png')} style={styles.avatar} />
           <Text style={styles.username}>vscotest40</Text>
           <View style={styles.profileActions}>
             <TouchableOpacity style={styles.editBtn}><Text style={styles.editText}>Edit</Text></TouchableOpacity>
@@ -106,6 +106,7 @@ const styles = StyleSheet.create({
     borderRadius: 36,
     marginBottom: 8,
     backgroundColor: '#eee',
+    overflow: 'hidden',
   },
   username: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
- display `AppSprite.png` on the profile screen
- use the same sprite image in the profile modal

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f26140988328b55cde7b3733df47