### PR TITLE
Add settings screen and navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -3,7 +3,7 @@ import { LogBox } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import TabNavigator from './src/navigation/TabNavigator';
+import RootNavigator from './src/navigation/RootNavigator';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -16,7 +16,7 @@ export default function App() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <NavigationContainer>
-          <TabNavigator />
+          <RootNavigator />
         </NavigationContainer>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "^1.20.2",
         "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native-stack": "^7.3.16",
         "@react-three/drei": "^10.2.0",
         "@react-three/fiber": "^9.1.2",
         "expo": "~53.0.11",
@@ -2776,17 +2777,17 @@
       }
     },
     "node_modules/@react-navigation/core": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.10.0.tgz",
-      "integrity": "sha512-qZBA5gGm+9liT4+EHk+kl9apwvqh7HqhLF1XeX6SQRmC/n2QI0u1B8OevKc+EPUDEM9Od15IuwT/GRbSs7/Umw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.10.1.tgz",
+      "integrity": "sha512-6+bdalOqfDzc968s3Xz7VaUpPzMKzVay48dW+C/cd6sga01Iqjp4XAzQ7FNHdT7wgJYdvZaBOAlyvnok0OsFZw==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/routers": "^7.4.0",
+        "@react-navigation/routers": "^7.4.1",
         "escape-string-regexp": "^4.0.0",
         "nanoid": "^3.3.11",
         "query-string": "^7.1.3",
         "react-is": "^19.1.0",
-        "use-latest-callback": "^0.2.3",
+        "use-latest-callback": "^0.2.4",
         "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
@@ -2794,16 +2795,17 @@
       }
     },
     "node_modules/@react-navigation/elements": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.3.tgz",
-      "integrity": "sha512-psoNmnZ0DQIt9nxxPITVLtYW04PGCAfnmd/Pcd3yhiBs93aj+HYKH+SDZDpUnXMf3BN7Wvo4+jPI+/Xjqb+m9w==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-2.4.4.tgz",
+      "integrity": "sha512-6OAzrg6mn8s3qv6DZSFHxYRZv/3hUZTtkrq1XNBqLNlVIv89Iv7XKukYbZIxNoUss8r+RLJea0aNAOq5jbBkfw==",
       "license": "MIT",
       "dependencies": {
-        "color": "^4.2.3"
+        "color": "^4.2.3",
+        "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
         "@react-native-masked-view/masked-view": ">= 0.2.0",
-        "@react-navigation/native": "^7.1.10",
+        "@react-navigation/native": "^7.1.11",
         "react": ">= 18.2.0",
         "react-native": "*",
         "react-native-safe-area-context": ">= 4.0.0"
@@ -2815,26 +2817,43 @@
       }
     },
     "node_modules/@react-navigation/native": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.10.tgz",
-      "integrity": "sha512-Ug4IML0DkAxZTMF/E7lyyLXSclkGAYElY2cxZWITwfBjtlVeda0NjsdnTWY5EGjnd7bwvhTIUC+CO6qSlrDn5A==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.11.tgz",
+      "integrity": "sha512-f/UETxy2Nahr8jko9mSSRBvIaDubGc3M2yx5pWxMPxZgLkB4TqPB0O1OFdbcAuRDwLgzXXK+Joh7nTdGug9v2A==",
       "license": "MIT",
       "dependencies": {
-        "@react-navigation/core": "^7.10.0",
+        "@react-navigation/core": "^7.10.1",
         "escape-string-regexp": "^4.0.0",
         "fast-deep-equal": "^3.1.3",
         "nanoid": "^3.3.11",
-        "use-latest-callback": "^0.2.3"
+        "use-latest-callback": "^0.2.4"
       },
       "peerDependencies": {
         "react": ">= 18.2.0",
         "react-native": "*"
       }
     },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "7.3.16",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.3.16.tgz",
+      "integrity": "sha512-tK29buswgQtHE/8+HMeYfsio/t6Y0Yk+YlEBckaYvNbxOrCwQ/s2FrM4dyV3dHkSefT6eEae3NKSgD0Q2ARMAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/elements": "^2.4.4",
+        "warn-once": "^0.1.1"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^7.1.11",
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-screens": ">= 4.0.0"
+      }
+    },
     "node_modules/@react-navigation/routers": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.0.tgz",
-      "integrity": "sha512-th5THnuWKJlmr7GGHiicy979di11ycDWub9iIXbEDvQwmwmsRzppmVbfs2nD8bC/MgyMgqWu/gxfys+HqN+kcw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-7.4.1.tgz",
+      "integrity": "sha512-42mZrMzQ0LfKxUb5OHIurYrPYyRsXFLolucILrvm21f0O40Sw0Ufh1bnn/jRqnxZZu7wvpUGIGYM8nS9zVE1Aw==",
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11"
@@ -9149,9 +9168,9 @@
       }
     },
     "node_modules/use-latest-callback": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.3.tgz",
-      "integrity": "sha512-7vI3fBuyRcP91pazVboc4qu+6ZqM8izPWX9k7cRnT8hbD5svslcknsh3S9BUhaK11OmgTV4oWZZVSeQAiV53SQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.4.tgz",
+      "integrity": "sha512-LS2s2n1usUUnDq4oVh1ca6JFX9uSqUncTfAm44WMg0v6TxL7POUTk1B044NH8TeLkFbNajIsgDHcgNpNzZucdg==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@react-native-async-storage/async-storage": "^1.20.2",
     "@react-navigation/bottom-tabs": "^7.3.14",
     "@react-navigation/native": "^7.1.10",
+    "@react-navigation/native-stack": "^7.3.16",
     "@react-three/drei": "^10.2.0",
     "@react-three/fiber": "^9.1.2",
     "expo": "~53.0.11",

--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import TabNavigator from './TabNavigator';
+import SettingsScreen from '../screens/SettingsScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Tabs" component={TabNavigator} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, Dimensions } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 
 const GALLERY_IMAGES = [
@@ -16,12 +17,13 @@ const CARD_SIZE = (SCREEN_WIDTH - 48) / 2;
 
 export default function ProfileScreen() {
   const [tab, setTab] = useState('Gallery');
+  const navigation = useNavigation();
 
   return (
     <View style={styles.container}>
       {/* Top Bar */}
       <View style={styles.topBar}>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate('Settings')}>
           <Ionicons name="settings-outline" size={24} color="#222" />
         </TouchableOpacity>
         <Text style={styles.usernameTop}>vscotest40</Text>

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+
+export default function SettingsScreen({ navigation }) {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Ionicons name="arrow-back" size={24} color="#222" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Settings</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <View style={styles.content}>
+        <View style={styles.sidebar}>
+          <TouchableOpacity style={styles.option}>
+            <Text style={styles.optionText}>Notifications</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.option}>
+            <Text style={styles.optionText}>Settings and Privacy</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.option}>
+            <Text style={styles.optionText}>Logout</Text>
+          </TouchableOpacity>
+        </View>
+        <View style={styles.placeholder}>
+          <Text style={styles.placeholderText}>Select an option</Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#222',
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'row',
+  },
+  sidebar: {
+    width: 160,
+    borderRightWidth: 1,
+    borderColor: '#eee',
+    paddingVertical: 16,
+  },
+  option: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  optionText: {
+    fontSize: 16,
+    color: '#222',
+    fontWeight: '500',
+  },
+  placeholder: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  placeholderText: {
+    fontSize: 16,
+    color: '#888',
+  },
+});


### PR DESCRIPTION
## Summary
- implement RootNavigator with native stack
- add new SettingsScreen with sidebar options and back button
- open settings screen from Profile via navigation
- switch App to use RootNavigator
- install @react-navigation/native-stack dependency

## Testing
- `npm start` *(fails: expo dev server limited due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_685232e252648328afb1eb2d215fddb7