### PR TITLE
Fix settings icon position

### DIFF
--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, Dimensions } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 
@@ -20,7 +21,7 @@ export default function ProfileScreen() {
   const navigation = useNavigation();
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       {/* Top Bar */}
       <View style={styles.topBar}>
         <TouchableOpacity onPress={() => navigation.navigate('Settings')}>
@@ -71,7 +72,7 @@ export default function ProfileScreen() {
           </View>
         )}
       </ScrollView>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -85,7 +86,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: 16,
-    paddingTop: 24,
+    paddingTop: 48,
     paddingBottom: 8,
     backgroundColor: '#fff',
   },


### PR DESCRIPTION
## Summary
- ensure safe area on profile screen
- lower settings icon

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852376f708c832891062143d851e865