### PR TITLE
Add Activity screen

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import TabNavigator from './TabNavigator';
 import SettingsScreen from '../screens/SettingsScreen';
+import ActivityScreen from '../screens/ActivityScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -10,6 +11,7 @@ export default function RootNavigator() {
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Tabs" component={TabNavigator} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
+      <Stack.Screen name="Activity" component={ActivityScreen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/ActivityScreen.js
+++ b/src/screens/ActivityScreen.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+
+export default function ActivityScreen({ navigation }) {
+  const activities = [
+    'nuha545 sent you a follow request',
+    'kenzie sent you a follow request',
+    'ayah sent you a follow request',
+  ];
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Ionicons name="arrow-back" size={24} color="#222" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Activity</Text>
+        <View style={{ width: 24 }} />
+      </View>
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        {activities.map((msg, idx) => (
+          <View key={idx} style={styles.activityItem}>
+            <Text style={styles.activityText}>{msg}</Text>
+          </View>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#222',
+  },
+  scrollContent: {
+    padding: 16,
+  },
+  activityItem: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+  activityText: {
+    fontSize: 16,
+    color: '#222',
+  },
+});

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -27,7 +27,7 @@ export default function ProfileScreen() {
         <TouchableOpacity onPress={() => navigation.navigate('Settings')}>
           <Ionicons name="settings-outline" size={32} color="#222" />
         </TouchableOpacity>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate('Activity')}>
           <Ionicons name="notifications-outline" size={24} color="#222" />
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
## Summary
- add Activity screen for follow notifications
- wire up navigation to Activity screen from profile notification bell
- register Activity screen in root stack

## Testing
- `npm start` *(fails: expo not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685241234554832883cbb100bac5edb5