### PR TITLE
Add clickable exp icon on gym page

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -288,6 +288,15 @@ export default function GymScreen() {
           </View>
         )}
       </ScrollView>
+      <View style={styles.expImageWrapper}>
+        <TouchableOpacity onPress={showStats}>
+          <Image
+            source={require('../../assets/app_background.png')}
+            style={styles.expImage}
+            resizeMode="contain"
+          />
+        </TouchableOpacity>
+      </View>
       <View style={styles.gameContainer}>
         <GameEngine
           systems={[Physics, TouchHandler]}
@@ -611,5 +620,13 @@ const styles = StyleSheet.create({
   },
   carouselItemTextSelected: {
     color: '#fff',
+  },
+  expImageWrapper: {
+    alignItems: 'center',
+    marginVertical: 16,
+  },
+  expImage: {
+    width: 150,
+    height: 150,
   },
 });


### PR DESCRIPTION
## Summary
- make the gym screen show `app_background.png` in the center
- clicking the image opens the stats modal displaying the experience circle

## Testing
- `npx expo start --max-workers=1`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68524313613c83289c4937cd5f626552