### PR TITLE
Add workout toggle button

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -63,6 +63,7 @@ export default function GymScreen() {
   const [editingExerciseIdx, setEditingExerciseIdx] = useState(null);
   const [showSummaryModal, setShowSummaryModal] = useState(false);
   const [weeklySummary, setWeeklySummary] = useState(null);
+  const [workoutActive, setWorkoutActive] = useState(false);
 
   const engine = useRef(Matter.Engine.create({ enableSleeping: false }));
   const world = engine.current.world;
@@ -266,6 +267,10 @@ export default function GymScreen() {
     setShowExerciseModal(false);
   };
 
+  const toggleWorkout = useCallback(() => {
+    setWorkoutActive(active => !active);
+  }, []);
+
   return (
     <ImageBackground
       source={require('../../assets/app_background.png')}
@@ -353,6 +358,12 @@ export default function GymScreen() {
 
       <TouchableOpacity style={styles.addWorkoutBtn} onPress={openNewWorkout}>
         <Ionicons name="add" size={32} color="#fff" />
+      </TouchableOpacity>
+
+      <TouchableOpacity style={styles.workoutToggleBtn} onPress={toggleWorkout}>
+        <Text style={styles.workoutToggleBtnText}>
+          {workoutActive ? 'END' : 'LIFT'}
+        </Text>
       </TouchableOpacity>
 
       {/* Summary Modal */}
@@ -640,5 +651,18 @@ const styles = StyleSheet.create({
   expImage: {
     width: 150,
     height: 150,
+  },
+  workoutToggleBtn: {
+    position: 'absolute',
+    bottom: 24,
+    left: 24,
+    backgroundColor: '#000',
+    borderRadius: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+  },
+  workoutToggleBtnText: {
+    color: '#fff',
+    fontWeight: '700',
   },
 });


### PR DESCRIPTION
## Summary
- add button state for beginning and ending a workout
- toggle button between **LIFT** and **END** when pressed

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537b83875c8328909205cf3d052f4f