### PR TITLE
Fix wiggle reset and adjust carousel spacing

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -68,7 +68,11 @@ const WiggleItem = React.memo(function WiggleItem({ deleteMode, style, children,
       if (loop.current) {
         loop.current.stop();
       }
-      anim.setValue(0);
+      Animated.timing(anim, { toValue: 0, duration: 80, useNativeDriver: true }).start(({ finished }) => {
+        if (finished) {
+          anim.setValue(0);
+        }
+      });
     }
 
     return () => {
@@ -387,6 +391,7 @@ export default function GymScreen() {
 
       <View style={styles.carouselContainer}>
         <ScrollView
+          style={styles.carouselScrollView}
           horizontal
           showsHorizontalScrollIndicator={false}
           contentContainerStyle={styles.carouselScroll}
@@ -697,7 +702,12 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   carouselContainer: {
-    paddingVertical: 12,
+    paddingBottom: 12,
+    paddingTop: 20,
+    marginTop: -8,
+  },
+  carouselScrollView: {
+    overflow: 'visible',
   },
   carouselScroll: {
     paddingHorizontal: 16,


### PR DESCRIPTION
## Summary
- ensure WiggleItem animation resets rotation
- increase space for delete icons in carousel and keep items positioned

## Testing
- `npm test` *(fails: Missing script)*
- `npm start -- --help` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537e91164483288409ff255bffb384