### PR TITLE
Adjust workout button position and size

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -751,15 +751,16 @@ const styles = StyleSheet.create({
   },
   workoutToggleBtn: {
     position: 'absolute',
-    bottom: 24,
-    left: 24,
+    alignSelf: 'center',
+    bottom: 160,
     backgroundColor: '#000',
     borderRadius: 8,
-    paddingVertical: 12,
-    paddingHorizontal: 20,
+    paddingVertical: 16,
+    paddingHorizontal: 26,
   },
   workoutToggleBtnText: {
     color: '#fff',
     fontWeight: '700',
+    fontSize: 21,
   },
 });


### PR DESCRIPTION
## Summary
- move the Lift/End button to the center above the workout carousel
- enlarge the button by about 30%

## Testing
- `npm start` *(fails: Expo CLI not found)*
- `npm install`
- `npm start` *(starts Metro Bundler)*

------
https://chatgpt.com/codex/tasks/task_e_68537f9b25008328833801c24f81eb8d