### PR TITLE
Allow custom exercises and update suggestions

### DIFF
--- a/src/components/ExerciseSelector.js
+++ b/src/components/ExerciseSelector.js
@@ -3,13 +3,11 @@ import { View, TextInput, TouchableOpacity, Text, StyleSheet } from 'react-nativ
 import { EXERCISES } from '../data/exerciseList';
 
 export default function ExerciseSelector({ value, onChange }) {
+  const query = value.trim().toLowerCase();
   const suggestions = useMemo(() => {
-    const query = value.trim().toLowerCase();
-    if (!query) {
-      return ['Barbell Squat', 'Barbell Bench Press', 'Dumbbell Lunge', 'Deadlift'];
-    }
+    if (!query) return [];
     return EXERCISES.filter(ex => ex.toLowerCase().includes(query)).slice(0, 4);
-  }, [value]);
+  }, [query]);
 
   return (
     <View>

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -24,7 +24,6 @@ import { useFocusEffect } from '@react-navigation/native';
 import ExpCircle from '../components/ExpCircle';
 import TouchHandler from '../systems/TouchHandler';
 import ExerciseSelector from '../components/ExerciseSelector';
-import { EXERCISES } from '../data/exerciseList';
 
 const SPRITE = require('../../assets/AppSprite.png');
 const SPRITE_SIZE = 120;
@@ -307,10 +306,6 @@ export default function GymScreen() {
 
   const handleSaveExercise = () => {
     const ex = { ...exerciseForm };
-    if (!EXERCISES.includes(ex.name)) {
-      Alert.alert('Please select a valid exercise from the list.');
-      return;
-    }
     setWorkouts(w => {
       const updated = [...w];
       const exercises = updated[currentWorkoutIdx].exercises;


### PR DESCRIPTION
## Summary
- show exercise suggestions only after typing
- remove restriction on exercises to match predefined list

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685387e6eac883288325af3e27c7ce6d