### PR TITLE
Fix wiggle cards not resetting angle

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -79,6 +79,7 @@ const WiggleItem = React.memo(function WiggleItem({ deleteMode, style, children,
       if (loop.current) {
         loop.current.stop();
       }
+      anim.setValue(0);
     };
   }, [deleteMode, anim]);
 
@@ -90,7 +91,12 @@ const WiggleItem = React.memo(function WiggleItem({ deleteMode, style, children,
   return (
     <AnimatedTouchable
       {...rest}
-      style={[style, deleteMode && { transform: [{ rotate }] }]}
+      style={[
+        style,
+        {
+          transform: [{ rotate: deleteMode ? rotate : '0deg' }],
+        },
+      ]}
     >
       {children}
     </AnimatedTouchable>


### PR DESCRIPTION
## Summary
- ensure wiggle animation resets card rotation when leaving delete mode
- stop animation loop and reset value on cleanup

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bde8c2cc83288fd11af13877691b