### PR TITLE
Fix duplicate key warning in HistoryScreen

### DIFF
--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -79,8 +79,8 @@ export default function HistoryScreen() {
               ))}
             </Picker>
             <View style={styles.weekHeader}>
-              {WEEK_DAYS.map(day => (
-                <Text key={day} style={styles.weekDay}>{day}</Text>
+              {WEEK_DAYS.map((day, i) => (
+                <Text key={`${day}-${i}`} style={styles.weekDay}>{day}</Text>
               ))}
             </View>
             <View style={styles.grid}>


### PR DESCRIPTION
## Summary
- eliminate duplicate keys for weekday headers

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bfd4ed2c83288c26ca60ee23ddb7