### PR TITLE
Add level badge overlay to profile avatars

### DIFF
--- a/src/components/AvatarWithLevelBadge.js
+++ b/src/components/AvatarWithLevelBadge.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Image, Text, StyleSheet } from 'react-native';
+
+export default function AvatarWithLevelBadge({ source, size = 72, level = 1 }) {
+  const borderRadius = size / 2;
+  return (
+    <View style={[styles.container, { width: size, height: size, borderRadius }]}>
+      <Image source={source} style={{ width: size, height: size, borderRadius }} />
+      {level != null && (
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>{level}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+    backgroundColor: '#eee',
+  },
+  badge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    backgroundColor: '#4CAF50',
+    borderRadius: 10,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    minWidth: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+});

--- a/src/components/ProfileModal.js
+++ b/src/components/ProfileModal.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { View, Text, StyleSheet, Modal, TouchableOpacity, Dimensions, Image } from 'react-native';
+import { View, Text, StyleSheet, Modal, TouchableOpacity, Dimensions } from 'react-native';
+import AvatarWithLevelBadge from './AvatarWithLevelBadge';
 import { Ionicons } from '@expo/vector-icons';
 
-export default function ProfileModal({ isVisible, onClose }) {
+export default function ProfileModal({ isVisible, onClose, level = 1 }) {
   return (
     <Modal
       visible={isVisible}
@@ -19,7 +20,11 @@ export default function ProfileModal({ isVisible, onClose }) {
 
           {/* Avatar */}
           <View style={styles.avatarContainer}>
-            <Image source={require('../../assets/AppSprite.png')} style={styles.avatarImage} />
+            <AvatarWithLevelBadge
+              source={require('../../assets/AppSprite.png')}
+              size={100}
+              level={level}
+            />
           </View>
 
           {/* User Info */}
@@ -93,10 +98,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 16,
     overflow: 'hidden',
-  },
-  avatarImage: {
-    width: '100%',
-    height: '100%',
   },
   username: {
     fontSize: 24,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
+import AvatarWithLevelBadge from '../components/AvatarWithLevelBadge';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
@@ -36,7 +37,11 @@ export default function ProfileScreen() {
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Profile Info */}
         <View style={styles.profileInfo}>
-          <Image source={require('../../assets/AppSprite.png')} style={styles.avatar} />
+          <AvatarWithLevelBadge
+            source={require('../../assets/AppSprite.png')}
+            size={72}
+            level={1}
+          />
           <Text style={styles.username}>vscotest40</Text>
           <View style={styles.profileActions}>
             <TouchableOpacity style={styles.editBtn}>
@@ -118,14 +123,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 8,
     marginBottom: 16,
-  },
-  avatar: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
-    marginBottom: 8,
-    backgroundColor: '#eee',
-    overflow: 'hidden',
   },
   username: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
- create `AvatarWithLevelBadge` component for showing profile levels
- use the badge component on the profile screen
- show the badge in `ProfileModal` as well

## Testing
- `npm start -- --clear` *(fails: expo not found)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854c41ac1048328ae1996f3f9fcdee2