### PR TITLE
Fix Image import in ProfileScreen

### DIFF
--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Image } from 'react-native';
 import AvatarWithLevelBadge from '../components/AvatarWithLevelBadge';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';


### PR DESCRIPTION
## Summary
- fix missing `Image` import for gallery render

## Testing
- `npm install`
- `EXPO_NO_INTERACTIVE=1 npx expo start --max-workers=1` *(fails: runs but requires interactive environment)*

------
https://chatgpt.com/codex/tasks/task_e_6854c711d2808328938ba5dfbf7e1730