### PR TITLE
Fix level badge placement

### DIFF
--- a/src/components/AvatarWithLevelBadge.js
+++ b/src/components/AvatarWithLevelBadge.js
@@ -18,13 +18,13 @@ export default function AvatarWithLevelBadge({ source, size = 72, level = 1 }) {
 const styles = StyleSheet.create({
   container: {
     position: 'relative',
-    overflow: 'hidden',
+    overflow: 'visible',
     backgroundColor: '#eee',
   },
   badge: {
     position: 'absolute',
-    bottom: -2,
-    right: -2,
+    top: -6,
+    right: -6,
     backgroundColor: '#4CAF50',
     borderRadius: 10,
     paddingHorizontal: 4,


### PR DESCRIPTION
## Summary
- move the level badge outside the avatar so it sits above the profile picture

## Testing
- `npm install`
- `npm start -- --max-workers=1` *(fails: Starting Metro Bundler)*

------
https://chatgpt.com/codex/tasks/task_e_6854cb280e548328aa176bc648125d10