### PR TITLE
Implement set tracking in workout grid

### DIFF
--- a/src/components/EquipmentGrid.js
+++ b/src/components/EquipmentGrid.js
@@ -38,6 +38,17 @@ export default function EquipmentGrid({ exercises = [], progress = [], onIncreme
           style={[styles.box, { left: pos.left, top: pos.top, width: cellWidth, height: cellHeight }]}
           onPress={() => onIncrement && onIncrement(idx)}
         >
+          <View style={styles.setRow}>
+            {Array.from({ length: pos.sets }).map((_, sIdx) => (
+              <View
+                key={sIdx}
+                style={[
+                  styles.setDot,
+                  (progress[idx] ?? 0) > sIdx && styles.setDotFilled,
+                ]}
+              />
+            ))}
+          </View>
           <Text style={styles.progress}>{(progress[idx] ?? 0)}/{pos.sets}</Text>
           <Text style={styles.label} numberOfLines={1} adjustsFontSizeToFit>
             {pos.name}
@@ -71,5 +82,20 @@ const styles = StyleSheet.create({
     color: '#007AFF',
     fontWeight: '700',
     marginBottom: 4,
+  },
+  setRow: {
+    flexDirection: 'row',
+    marginBottom: 4,
+  },
+  setDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    borderWidth: 1,
+    borderColor: '#007AFF',
+    marginHorizontal: 1,
+  },
+  setDotFilled: {
+    backgroundColor: '#007AFF',
   },
 });

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -382,6 +382,7 @@ export default function GymScreen() {
         const max = parseInt(currentExercises[idx]?.sets, 10) || 0;
         if (updated[idx] < max) {
           updated[idx] += 1;
+          setExp(e => e + 1);
         }
         return updated;
       });


### PR DESCRIPTION
## Summary
- add set progress indicators to `EquipmentGrid`
- grant EXP per completed set during workouts

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found or requires updates, shows warning)*

------
https://chatgpt.com/codex/tasks/task_e_6854cbcbe5bc8328b63dd1a79e276a85