### PR TITLE
Fix sprite location in HistoryScreen

### DIFF
--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -146,8 +146,8 @@ export default function HistoryScreen() {
                     disabled={!completed}
                   >
                     {day && <Text style={styles.dayText}>{day}</Text>}
-                    {selected.year === today.getFullYear() &&
-                      selected.month === today.getMonth() &&
+                    {m.year === today.getFullYear() &&
+                      m.month === today.getMonth() &&
                       day === today.getDate() && (
                         <Image source={SPRITE} style={styles.sprite} />
                       )}


### PR DESCRIPTION
## Summary
- fix sprite rendering logic so sprite only appears on the current day's cell in the current month
- verify build with `npm start`

## Testing
- `npm install`
- `npm start` *(fails: waiting on expo start)*

------
https://chatgpt.com/codex/tasks/task_e_6854df2036a88328a1ffcb6f24494b73