### PR TITLE
Persist workout history and improve modal

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -20,6 +20,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
+import { toDateKey } from '../utils/dateUtils';
 import ExpCircle from '../components/ExpCircle';
 import TouchHandler from '../systems/TouchHandler';
 import ExerciseSelector from '../components/ExerciseSelector';
@@ -392,7 +393,7 @@ export default function GymScreen() {
     setWorkoutActive(active => {
       const next = !active;
       if (active && !next) {
-        const dateStr = new Date().toISOString().split('T')[0];
+        const dateStr = toDateKey();
         setWorkoutHistory(h => ({
           ...h,
           [dateStr]: {

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,7 @@
+export function toDateKey(date = new Date()) {
+  const d = new Date(date);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary
- persist workout history using local date keys
- reload history screen whenever focused
- show completed set count in history modal
- add helper for generating local date keys

## Testing
- `npm start` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68574bb9f3c083288e302421e20385fe