### PR TITLE
Update history automatically

### DIFF
--- a/App.js
+++ b/App.js
@@ -5,6 +5,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import RootNavigator from './src/navigation/RootNavigator';
 import { CharacterProvider } from './src/context/CharacterContext';
+import { HistoryProvider } from './src/context/HistoryContext';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -16,11 +17,13 @@ export default function App() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
-        <CharacterProvider>
-          <NavigationContainer>
-            <RootNavigator />
-          </NavigationContainer>
-        </CharacterProvider>
+        <HistoryProvider>
+          <CharacterProvider>
+            <NavigationContainer>
+              <RootNavigator />
+            </NavigationContainer>
+          </CharacterProvider>
+        </HistoryProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/src/context/HistoryContext.js
+++ b/src/context/HistoryContext.js
@@ -1,0 +1,38 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const HistoryContext = createContext({
+  history: {},
+  addEntry: (dateStr, workout) => {},
+});
+
+export const HistoryProvider = ({ children }) => {
+  const [history, setHistory] = useState({});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('workoutHistory');
+        if (stored) {
+          setHistory(JSON.parse(stored));
+        }
+      } catch {}
+    })();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('workoutHistory', JSON.stringify(history));
+  }, [history]);
+
+  const addEntry = useCallback((dateStr, workout) => {
+    setHistory(h => ({ ...h, [dateStr]: workout }));
+  }, []);
+
+  return (
+    <HistoryContext.Provider value={{ history, addEntry }}>
+      {children}
+    </HistoryContext.Provider>
+  );
+};
+
+export const useHistory = () => useContext(HistoryContext);

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -20,6 +20,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
+import { useHistory } from '../context/HistoryContext';
 import { toDateKey } from '../utils/dateUtils';
 import ExpCircle from '../components/ExpCircle';
 import TouchHandler from '../systems/TouchHandler';
@@ -124,7 +125,7 @@ export default function GymScreen() {
   const [workoutActive, setWorkoutActive] = useState(false);
   const [deleteMode, setDeleteMode] = useState(false);
   const [setCounts, setSetCounts] = useState([]);
-  const [workoutHistory, setWorkoutHistory] = useState({});
+  const { addEntry } = useHistory();
 
   const engine = useRef(Matter.Engine.create({ enableSleeping: false }));
   const world = engine.current.world;
@@ -173,22 +174,12 @@ export default function GymScreen() {
           setWorkouts(JSON.parse(stored));
         } catch {}
       }
-      const hist = await AsyncStorage.getItem('workoutHistory');
-      if (hist) {
-        try {
-          setWorkoutHistory(JSON.parse(hist));
-        } catch {}
-      }
     })();
   }, []);
 
   useEffect(() => {
     AsyncStorage.setItem('workouts', JSON.stringify(workouts));
   }, [workouts]);
-
-  useEffect(() => {
-    AsyncStorage.setItem('workoutHistory', JSON.stringify(workoutHistory));
-  }, [workoutHistory]);
 
   // ensure selected workout index stays valid when workouts change
   useEffect(() => {
@@ -387,20 +378,17 @@ export default function GymScreen() {
       const next = !active;
       if (active && !next) {
         const dateStr = toDateKey();
-        setWorkoutHistory(h => ({
-          ...h,
-          [dateStr]: {
-            ...workouts[selectedWorkoutIdx],
-            completedSets: setCounts,
-          },
-        }));
+        addEntry(dateStr, {
+          ...workouts[selectedWorkoutIdx],
+          completedSets: setCounts,
+        });
         setSetCounts([]);
       } else if (next) {
         setSetCounts(currentExercises.map(() => 0));
       }
       return next;
     });
-  }, [workouts, selectedWorkoutIdx, currentExercises]);
+  }, [workouts, selectedWorkoutIdx, currentExercises, addEntry]);
 
   useEffect(() => {
     if (workoutActive) {

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Image, Dimensions, TouchableOpacity, Modal } from 'react-native';
-import { useFocusEffect } from "@react-navigation/native";
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useHistory } from '../context/HistoryContext';
 import { Picker } from '@react-native-picker/picker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -53,7 +52,7 @@ export default function HistoryScreen() {
     monthOptions[monthOptions.length - 1]
   );
   const [showPicker, setShowPicker] = useState(false);
-  const [history, setHistory] = useState({});
+  const { history } = useHistory();
   const [selectedEntry, setSelectedEntry] = useState(null);
   const [weekWeight, setWeekWeight] = useState(0);
   const [yearWeight, setYearWeight] = useState(0);
@@ -81,22 +80,6 @@ export default function HistoryScreen() {
     }
   };
 
-  useFocusEffect(
-    React.useCallback(() => {
-      let mounted = true;
-      (async () => {
-        const stored = await AsyncStorage.getItem("workoutHistory");
-        if (stored && mounted) {
-          try {
-            setHistory(JSON.parse(stored));
-          } catch {}
-        }
-      })();
-      return () => {
-        mounted = false;
-      };
-    }, [])
-  );
 
   useEffect(() => {
     const now = new Date();


### PR DESCRIPTION
## Summary
- create `HistoryContext` to store workout history globally
- wrap app with `HistoryProvider`
- update `GymScreen` to add history entries when ending a workout
- use shared history in `HistoryScreen`

## Testing
- `npm install`
- `npm start` *(fails: Launching dev server, then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_68574cb432508328a22cb8d5f7b9d951