### PR TITLE
Implement persistent workout stats

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,6 +6,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import RootNavigator from './src/navigation/RootNavigator';
 import { CharacterProvider } from './src/context/CharacterContext';
 import { HistoryProvider } from './src/context/HistoryContext';
+import { StatsProvider } from './src/context/StatsContext';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -18,11 +19,13 @@ export default function App() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <HistoryProvider>
-          <CharacterProvider>
-            <NavigationContainer>
-              <RootNavigator />
-            </NavigationContainer>
-          </CharacterProvider>
+          <StatsProvider>
+            <CharacterProvider>
+              <NavigationContainer>
+                <RootNavigator />
+              </NavigationContainer>
+            </CharacterProvider>
+          </StatsProvider>
         </HistoryProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>

--- a/src/context/StatsContext.js
+++ b/src/context/StatsContext.js
@@ -1,0 +1,99 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const StatsContext = createContext({
+  weekWeight: 0,
+  yearWeight: 0,
+  liftCount: 0,
+  addWorkout: (weight, hadSets) => {},
+});
+
+const STATS_KEY = 'userStats';
+
+function getNextSundayReset(date = new Date()) {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = (7 - day) % 7; // days until next Sunday
+  d.setDate(d.getDate() + diff);
+  d.setHours(23, 59, 0, 0);
+  return d.getTime();
+}
+
+function getNextYearReset(date = new Date()) {
+  const d = new Date(date);
+  const end = new Date(d.getFullYear(), 11, 31, 23, 59, 0, 0);
+  if (d > end) end.setFullYear(d.getFullYear() + 1);
+  return end.getTime();
+}
+
+export const StatsProvider = ({ children }) => {
+  const [stats, setStats] = useState({
+    weekWeight: 0,
+    yearWeight: 0,
+    liftCount: 0,
+    weekReset: getNextSundayReset(),
+    yearReset: getNextYearReset(),
+  });
+
+  // load saved stats
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STATS_KEY);
+        if (stored) {
+          const data = JSON.parse(stored);
+          setStats(s => ({
+            weekWeight: data.weekWeight || 0,
+            yearWeight: data.yearWeight || 0,
+            liftCount: data.liftCount || 0,
+            weekReset: data.weekReset || getNextSundayReset(),
+            yearReset: data.yearReset || getNextYearReset(),
+          }));
+        }
+      } catch {}
+    })();
+  }, []);
+
+  // persist stats whenever they change
+  useEffect(() => {
+    AsyncStorage.setItem(STATS_KEY, JSON.stringify(stats));
+  }, [stats]);
+
+  const addWorkout = useCallback((weight, hadSets) => {
+    setStats(prev => {
+      const now = Date.now();
+      let { weekWeight, yearWeight, liftCount, weekReset, yearReset } = prev;
+      if (now >= weekReset) {
+        weekWeight = 0;
+        weekReset = getNextSundayReset(now);
+      }
+      if (now >= yearReset) {
+        yearWeight = 0;
+        yearReset = getNextYearReset(now);
+      }
+      if (weight > 0) {
+        weekWeight += weight;
+        yearWeight += weight;
+      }
+      if (hadSets) {
+        liftCount = Math.min(liftCount + 1, 10000);
+      }
+      return { weekWeight, yearWeight, liftCount, weekReset, yearReset };
+    });
+  }, []);
+
+  return (
+    <StatsContext.Provider
+      value={{
+        weekWeight: stats.weekWeight,
+        yearWeight: stats.yearWeight,
+        liftCount: stats.liftCount,
+        addWorkout,
+      }}
+    >
+      {children}
+    </StatsContext.Provider>
+  );
+};
+
+export const useStats = () => useContext(StatsContext);

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -21,6 +21,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
 import { useHistory } from '../context/HistoryContext';
+import { useStats } from '../context/StatsContext';
 import { toDateKey } from '../utils/dateUtils';
 import ExpCircle from '../components/ExpCircle';
 import TouchHandler from '../systems/TouchHandler';
@@ -146,6 +147,7 @@ export default function GymScreen() {
   }, [world, characterBody]);
 
   const { exp, level, addExp } = useCharacter();
+  const { addWorkout } = useStats();
   const [showStatsModal, setShowStatsModal] = useState(false);
 
   const showStats = useCallback(() => {
@@ -384,6 +386,15 @@ const toggleWorkout = useCallback(() => {
           ...workouts[selectedWorkoutIdx],
           completedSets: setCounts,
         });
+
+        let weight = 0;
+        workouts[selectedWorkoutIdx].exercises.forEach((ex, idx) => {
+          const setsDone = setCounts[idx] || 0;
+          const reps = parseInt(ex.reps, 10) || 0;
+          const w = parseFloat(ex.weight) || 0;
+          weight += setsDone * reps * w;
+        });
+        addWorkout(weight, true);
       }
       setSetCounts([]);
     } else if (next) {
@@ -391,7 +402,7 @@ const toggleWorkout = useCallback(() => {
     }
     return next;
   });
-}, [workouts, selectedWorkoutIdx, currentExercises, setCounts, addEntry]);
+}, [workouts, selectedWorkoutIdx, currentExercises, setCounts, addEntry, addWorkout]);
 
   useEffect(() => {
     if (workoutActive) {

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Image, Dimensions, TouchableOpacity, Modal } from 'react-native';
 import { useHistory } from '../context/HistoryContext';
+import { useStats } from '../context/StatsContext';
 import { Picker } from '@react-native-picker/picker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -27,14 +28,6 @@ function generateMonth(year, month) {
   return { year, month, days };
 }
 
-function getStartOfWeek(date) {
-  const d = new Date(date);
-  const day = d.getDay();
-  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
-  d.setDate(diff);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
 
 export default function HistoryScreen() {
   const today = new Date();
@@ -53,10 +46,8 @@ export default function HistoryScreen() {
   );
   const [showPicker, setShowPicker] = useState(false);
   const { history } = useHistory();
+  const { weekWeight, yearWeight, liftCount } = useStats();
   const [selectedEntry, setSelectedEntry] = useState(null);
-  const [weekWeight, setWeekWeight] = useState(0);
-  const [yearWeight, setYearWeight] = useState(0);
-  const [liftCount, setLiftCount] = useState(0);
 
   // Pre-compute all months so users can swipe between them
   const months = monthOptions.map(opt => generateMonth(opt.year, opt.month));
@@ -81,36 +72,6 @@ export default function HistoryScreen() {
   };
 
 
-  useEffect(() => {
-    const now = new Date();
-    const startOfWeek = getStartOfWeek(now);
-    const startOfYear = new Date(now.getFullYear(), 0, 1);
-    let week = 0;
-    let year = 0;
-    let count = 0;
-    Object.entries(history).forEach(([dateStr, data]) => {
-      const dt = new Date(dateStr);
-      let weight = 0;
-      let setsTotal = 0;
-      data.exercises.forEach((ex, idx) => {
-        const setsDone =
-          data.completedSets && data.completedSets[idx] !== undefined
-            ? data.completedSets[idx]
-            : 0;
-        setsTotal += setsDone;
-        const reps = parseInt(ex.reps, 10) || 0;
-        const w = parseFloat(ex.weight) || 0;
-        weight += setsDone * reps * w;
-      });
-      if (setsTotal === 0) return;
-      if (dt >= startOfWeek) week += weight;
-      if (dt >= startOfYear) year += weight;
-      count += 1;
-    });
-    setWeekWeight(week);
-    setYearWeight(year);
-    setLiftCount(count);
-  }, [history]);
 
   return (
     <SafeAreaView style={styles.container}>


### PR DESCRIPTION
## Summary
- track weekly, yearly and lifetime workout stats via new `StatsContext`
- wrap navigator with `StatsProvider`
- update `GymScreen` to record stats when ending a workout
- show tracked values in `HistoryScreen`

## Testing
- `npm start` *(fails: expo not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857501f8c608328a73fcbc435f6a653