### PR TITLE
Align share button with stats

### DIFF
--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -252,7 +252,7 @@ const styles = StyleSheet.create({
   statsWrapper: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     paddingHorizontal: 16,
     marginBottom: 8,
   },
@@ -267,6 +267,7 @@ const styles = StyleSheet.create({
   },
   shareBtn: {
     padding: 8,
+    alignSelf: 'flex-start',
   },
   dayCell: {
     width: CELL_SIZE,


### PR DESCRIPTION
## Summary
- adjust layout so the share button lines up with stats text

## Testing
- `npm test` *(fails: Missing script)*
- `npm start -- --no-interactive` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857553ee4188328be352511b9c9c9e3