### PR TITLE
Add media upload button on profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.16",
         "expo": "~53.0.11",
+        "expo-av": "^15.1.6",
+        "expo-image-picker": "^16.1.4",
         "matter-js": "^0.20.0",
         "react": "19.0.0",
         "react-native": "0.79.3",
@@ -4369,6 +4371,23 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-av": {
+      "version": "15.1.6",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.6.tgz",
+      "integrity": "sha512-5ZbeXdCmdckZHwtEV+8tRZqLlUWR96gkkUIxpyZAEvK0L+aI/BnyhDCpjnSKWwZo4ZA6lx8/su9kyFNV/mQ/sQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-constants": {
       "version": "17.1.6",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.6.tgz",
@@ -4404,6 +4423,27 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.16",
     "expo": "~53.0.11",
+    "expo-av": "^15.1.6",
+    "expo-image-picker": "^16.1.4",
     "matter-js": "^0.20.0",
     "react": "19.0.0",
     "react-native": "0.79.3",


### PR DESCRIPTION
## Summary
- add `expo-image-picker` and `expo-av` for media upload and playback
- always show plus button on profile tabs
- allow picking photo or video to append to gallery

## Testing
- `npm start` *(fails due to interactive server; aborted after startup message)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68575d51dc208328af5b0b491ca33975