### PR TITLE
Adjust vertical spacing in GymScreen workout card

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -717,7 +717,8 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     padding: 16,
-    paddingBottom: 80,
+    // Reduce bottom padding so the workout card takes less vertical space
+    paddingBottom: 20,
   },
   workoutCard: {
     backgroundColor: '#fff',


### PR DESCRIPTION
## Summary
- reduce bottom padding on GymScreen's content container so the workout card occupies less space

## Testing
- `npm install`
- `npm start` *(fails: Expo can't fully run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68575de7481c8328ad2be66e12a3cfe8