### PR TITLE
Fix deprecation warning in image picker

### DIFF
--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -35,7 +35,7 @@ export default function ProfileScreen() {
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.All,
+      mediaTypes: ['images', 'videos'],
       allowsMultipleSelection: false,
       quality: 1,
     });


### PR DESCRIPTION
## Summary
- use new `ImagePicker.MediaType` array instead of deprecated `MediaTypeOptions`

## Testing
- `npm start`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68575ea14c748328af2ac7cf5749cf28