### PR TITLE
Add fullscreen view for gallery media

### DIFF
--- a/src/screens/ExploreScreen.js
+++ b/src/screens/ExploreScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, ImageBackground, ScrollView, TouchableOpacity, Image, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, ImageBackground, ScrollView, TouchableOpacity, Image, Dimensions, Modal, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
 const stories = [
@@ -25,6 +25,7 @@ const CARD_HEIGHT = SCREEN_HEIGHT / 2.2; // 2 cards fit at once, with padding
 
 export default function ExploreScreen() {
   const [liked, setLiked] = useState([false, false, false, false]);
+  const [fullImage, setFullImage] = useState(null);
 
   const toggleLike = idx => {
     setLiked(liked => liked.map((v, i) => (i === idx ? !v : v)));
@@ -54,7 +55,9 @@ export default function ExploreScreen() {
         <View style={styles.postsContainer}>
           {posts.map((post, idx) => (
             <View key={idx} style={styles.postCard}>
-              <Image source={post.image} style={styles.postImage} resizeMode="cover" />
+              <TouchableOpacity onPress={() => setFullImage(post.image)}>
+                <Image source={post.image} style={styles.postImage} resizeMode="cover" />
+              </TouchableOpacity>
               <View style={styles.postFooter}>
                 <Text style={styles.postName}>{post.name}</Text>
                 <TouchableOpacity style={styles.heartButton} onPress={() => toggleLike(idx)}>
@@ -65,6 +68,13 @@ export default function ExploreScreen() {
           ))}
         </View>
       </ScrollView>
+      <Modal visible={!!fullImage} transparent onRequestClose={() => setFullImage(null)}>
+        <Pressable style={styles.fullscreenContainer} onPress={() => setFullImage(null)}>
+          {fullImage && (
+            <Image source={fullImage} style={styles.fullscreenImage} resizeMode="contain" />
+          )}
+        </Pressable>
+      </Modal>
     </ImageBackground>
   );
 }
@@ -146,4 +156,14 @@ const styles = StyleSheet.create({
   heartButton: {
     padding: 6,
   },
-}); 
+  fullscreenContainer: {
+    flex: 1,
+    backgroundColor: 'black',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fullscreenImage: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Image } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Dimensions, Image, Modal, Pressable } from 'react-native';
 import { Video } from 'expo-av';
 import * as ImagePicker from 'expo-image-picker';
 import AvatarWithLevelBadge from '../components/AvatarWithLevelBadge';
@@ -20,6 +20,7 @@ export default function ProfileScreen() {
   const [tab, setTab] = useState('Gallery');
   const [galleryItems, setGalleryItems] = useState(INITIAL_GALLERY);
   const [privateItems, setPrivateItems] = useState(INITIAL_PRIVATE);
+  const [fullscreenItem, setFullscreenItem] = useState(null);
   const navigation = useNavigation();
   const { level } = useCharacter();
 
@@ -109,7 +110,7 @@ export default function ProfileScreen() {
           ) : (
             <View style={styles.galleryGrid}>
               {galleryItems.map((item, idx) => (
-                <View key={idx} style={styles.galleryCard}>
+                <TouchableOpacity key={idx} style={styles.galleryCard} onPress={() => setFullscreenItem(item)}>
                   {item.type === 'video' ? (
                     <Video
                       source={{ uri: typeof item.uri === 'number' ? undefined : item.uri }}
@@ -124,7 +125,7 @@ export default function ProfileScreen() {
                       resizeMode="cover"
                     />
                   )}
-                </View>
+                </TouchableOpacity>
               ))}
             </View>
           )
@@ -136,7 +137,7 @@ export default function ProfileScreen() {
           ) : (
             <View style={styles.galleryGrid}>
               {privateItems.map((item, idx) => (
-                <View key={idx} style={styles.galleryCard}>
+                <TouchableOpacity key={idx} style={styles.galleryCard} onPress={() => setFullscreenItem(item)}>
                   {item.type === 'video' ? (
                     <Video
                       source={{ uri: typeof item.uri === 'number' ? undefined : item.uri }}
@@ -151,12 +152,31 @@ export default function ProfileScreen() {
                       resizeMode="cover"
                     />
                   )}
-                </View>
+                </TouchableOpacity>
               ))}
             </View>
           )
         )}
       </ScrollView>
+      <Modal visible={!!fullscreenItem} transparent onRequestClose={() => setFullscreenItem(null)}>
+        <Pressable style={styles.fullscreenContainer} onPress={() => setFullscreenItem(null)}>
+          {fullscreenItem?.type === 'video' ? (
+            <Video
+              source={{ uri: typeof fullscreenItem.uri === 'number' ? undefined : fullscreenItem.uri }}
+              style={styles.fullscreenMedia}
+              resizeMode="contain"
+              useNativeControls
+              shouldPlay
+            />
+          ) : (
+            <Image
+              source={typeof fullscreenItem?.uri === 'number' ? fullscreenItem.uri : { uri: fullscreenItem?.uri }}
+              style={styles.fullscreenMedia}
+              resizeMode="contain"
+            />
+          )}
+        </Pressable>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -277,6 +297,16 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   galleryImg: {
+    width: '100%',
+    height: '100%',
+  },
+  fullscreenContainer: {
+    flex: 1,
+    backgroundColor: 'black',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fullscreenMedia: {
     width: '100%',
     height: '100%',
   },


### PR DESCRIPTION
## Summary
- allow Explore posts to open fullscreen
- allow Profile gallery items to open fullscreen

## Testing
- `npm start -- -h` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857697b92608328a0d11f0f91bebc9c