### PR TITLE
Move workout sprite downward

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -133,9 +133,15 @@ export default function GymScreen() {
   const { width, height } = Dimensions.get('window');
 
   const characterBody = useRef(
-    Matter.Bodies.rectangle(width / 2, height / 2, SPRITE_SIZE, SPRITE_SIZE, {
-      isStatic: true,
-    })
+    Matter.Bodies.rectangle(
+      width / 2,
+      height / 2 + height * 0.1,
+      SPRITE_SIZE,
+      SPRITE_SIZE,
+      {
+        isStatic: true,
+      }
+    )
   ).current;
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- move the sprite slightly lower on the Gym screen

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576e6962d88328b00b56028e2915e3