### PR TITLE
Add weight formatting for history stats

### DIFF
--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -5,6 +5,7 @@ import { useHistory } from '../context/HistoryContext';
 import { useStats } from '../context/StatsContext';
 import { Picker } from '@react-native-picker/picker';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { formatWeight } from '../utils/numberUtils';
 
 const SPRITE = require('../../assets/AppSprite.png');
 
@@ -165,8 +166,8 @@ export default function HistoryScreen() {
       </ScrollView>
       <View style={styles.statsWrapper}>
         <View style={styles.statsContainer}>
-          <Text style={styles.statsText}>Weight lifted this week: {weekWeight}</Text>
-          <Text style={styles.statsText}>Weight lifted this year: {yearWeight}</Text>
+          <Text style={styles.statsText}>Weight lifted this week: {formatWeight(weekWeight)}</Text>
+          <Text style={styles.statsText}>Weight lifted this year: {formatWeight(yearWeight)}</Text>
           <Text style={styles.statsText}>Lifts since download: {liftCount}</Text>
         </View>
         <TouchableOpacity style={styles.shareBtn} onPress={shareStats}>

--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -1,0 +1,6 @@
+export function formatWeight(weight) {
+  if (weight >= 100000) {
+    return `${Math.round(weight / 1000)}k`;
+  }
+  return weight.toLocaleString();
+}


### PR DESCRIPTION
## Summary
- support large weight display
- show week/year weight in abbreviated `k` format once it exceeds `99,999`

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576f2abd6c8328954e489a5f9e7d60