### PR TITLE
Allow multiple workouts per day

### DIFF
--- a/src/context/HistoryContext.js
+++ b/src/context/HistoryContext.js
@@ -14,7 +14,14 @@ export const HistoryProvider = ({ children }) => {
       try {
         const stored = await AsyncStorage.getItem('workoutHistory');
         if (stored) {
-          setHistory(JSON.parse(stored));
+          const data = JSON.parse(stored);
+          const normalized = Object.fromEntries(
+            Object.entries(data).map(([date, entry]) => [
+              date,
+              Array.isArray(entry) ? entry : [entry],
+            ])
+          );
+          setHistory(normalized);
         }
       } catch {}
     })();
@@ -25,7 +32,14 @@ export const HistoryProvider = ({ children }) => {
   }, [history]);
 
   const addEntry = useCallback((dateStr, workout) => {
-    setHistory(h => ({ ...h, [dateStr]: workout }));
+    setHistory(h => {
+      const dayEntries = h[dateStr] ? [...h[dateStr]] : [];
+      dayEntries.push(workout);
+      if (dayEntries.length > 3) {
+        dayEntries.shift();
+      }
+      return { ...h, [dateStr]: dayEntries };
+    });
   }, []);
 
   return (

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -391,6 +391,7 @@ const toggleWorkout = useCallback(() => {
         addEntry(dateStr, {
           ...workouts[selectedWorkoutIdx],
           completedSets: setCounts,
+          timestamp: Date.now(),
         });
 
         let weight = 0;

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -143,12 +143,15 @@ export default function HistoryScreen() {
                 const dateStr = day
                   ? `${m.year}-${String(m.month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
                   : null;
-                const completed = !!(dateStr && history[dateStr]);
+                const completed = !!(dateStr && history[dateStr] && history[dateStr].length);
                 return (
                   <TouchableOpacity
                     key={i}
                     style={[styles.dayCell, completed && styles.completedDay]}
-                    onPress={() => completed && setSelectedEntry(history[dateStr])}
+                    onPress={() =>
+                      completed &&
+                      setSelectedEntry({ workouts: history[dateStr] })
+                    }
                     disabled={!completed}
                   >
                     {day && <Text style={styles.dayText}>{day}</Text>}
@@ -182,25 +185,30 @@ export default function HistoryScreen() {
         <Modal visible transparent animationType="fade">
           <View style={styles.modalOverlay}>
             <View style={styles.modalContent}>
-              <Text style={styles.modalTitle}>{selectedEntry.name}</Text>
-              {selectedEntry.exercises?.map((ex, idx) => {
-                const setsDone =
-                  selectedEntry.completedSets &&
-                  selectedEntry.completedSets[idx] !== undefined
-                    ? selectedEntry.completedSets[idx]
-                    : 0;
-                return (
-                  <Text key={idx} style={styles.modalText}>
-                    {ex.name} - {setsDone}x{ex.reps} @ {ex.weight}
-                  </Text>
-                );
-              })}
-              <TouchableOpacity
-                style={styles.modalButton}
-                onPress={() => setSelectedEntry(null)}
-              >
-                <Text style={styles.modalButtonText}>Close</Text>
-              </TouchableOpacity>
+              <ScrollView>
+                {selectedEntry.workouts.map((w, wi) => (
+                  <View key={wi} style={styles.workoutSection}>
+                    <Text style={styles.modalSubtitle}>{w.name}</Text>
+                    {w.exercises?.map((ex, idx) => {
+                      const setsDone =
+                        w.completedSets && w.completedSets[idx] !== undefined
+                          ? w.completedSets[idx]
+                          : 0;
+                      return (
+                        <Text key={idx} style={styles.modalText}>
+                          {ex.name} - {setsDone}x{ex.reps} @ {ex.weight}
+                        </Text>
+                      );
+                    })}
+                  </View>
+                ))}
+                <TouchableOpacity
+                  style={styles.modalButton}
+                  onPress={() => setSelectedEntry(null)}
+                >
+                  <Text style={styles.modalButtonText}>Close</Text>
+                </TouchableOpacity>
+              </ScrollView>
             </View>
           </View>
         </Modal>
@@ -317,10 +325,21 @@ const styles = StyleSheet.create({
     color: '#222',
     textAlign: 'center',
   },
+  modalSubtitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 4,
+    color: '#222',
+    textAlign: 'center',
+  },
   modalText: {
     color: '#222',
     marginBottom: 4,
     textAlign: 'center',
+  },
+  workoutSection: {
+    marginBottom: 12,
+    alignItems: 'center',
   },
   modalButton: {
     backgroundColor: '#007AFF',


### PR DESCRIPTION
## Summary
- normalize stored history to store up to three workouts per day
- queue new workouts in history when exceeding the limit
- record timestamps when workouts are added
- display all workouts logged for a day in History modal

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a30b6f64c8328abfe850c5c53c092