### PR TITLE
Move avatar lower on Gym screen

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -135,7 +135,8 @@ export default function GymScreen() {
   const characterBody = useRef(
     Matter.Bodies.rectangle(
       width / 2,
-      height / 2 + height * 0.1,
+      // Move the character slightly lower so it's closer to the middle of the screen
+      height / 2 + height * 0.2,
       SPRITE_SIZE,
       SPRITE_SIZE,
       {


### PR DESCRIPTION
## Summary
- tweak the y-position of the character body in `GymScreen` so the avatar appears slightly lower in the game area

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a30ec5c148328be63018b4c6309e0