### PR TITLE
Increase equipment image size

### DIFF
--- a/src/components/EquipmentGrid.js
+++ b/src/components/EquipmentGrid.js
@@ -73,8 +73,8 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   equipmentImage: {
-    width: '80%',
-    height: '60%',
+    width: '104%',
+    height: '78%',
     marginBottom: 4,
   },
   label: {


### PR DESCRIPTION
## Summary
- increase gym equipment images 30% so they are more visible

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685a36be67a48328a9080330aa200883