### PR TITLE
Adjust equipment grid spacing

### DIFF
--- a/src/components/EquipmentGrid.js
+++ b/src/components/EquipmentGrid.js
@@ -68,14 +68,14 @@ const styles = StyleSheet.create({
   },
   box: {
     position: 'absolute',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'center',
     borderRadius: 8,
   },
   equipmentImage: {
     width: '110%',
     height: '110%',
-    marginBottom: 4,
+    marginBottom: 2,
   },
   label: {
     color: '#222',
@@ -85,11 +85,11 @@ const styles = StyleSheet.create({
   progress: {
     color: '#007AFF',
     fontWeight: '700',
-    marginBottom: 4,
+    marginBottom: 2,
   },
   setRow: {
     flexDirection: 'row',
-    marginBottom: 4,
+    marginBottom: 2,
   },
   setDot: {
     width: 8,


### PR DESCRIPTION
## Summary
- shift box content to start of container so progress and titles sit closer to the equipment image
- reduce margins on image, progress, and set row

## Testing
- `npm install`
- `npx expo start` *(fails: unknown or unexpected option)*

------
https://chatgpt.com/codex/tasks/task_e_685b4cbf99a083289c8fca732fa73668