### PR TITLE
Enable swipe navigation between tabs

### DIFF
--- a/src/navigation/useSwipeTabs.js
+++ b/src/navigation/useSwipeTabs.js
@@ -1,0 +1,30 @@
+import { useRef } from 'react';
+import { PanResponder } from 'react-native';
+import { useNavigation, useRoute } from '@react-navigation/native';
+
+export const TAB_ORDER = ['Profile', 'Gym', 'History', 'Login'];
+
+export default function useSwipeTabs(order = TAB_ORDER) {
+  const navigation = useNavigation();
+  const route = useRoute();
+
+  const responder = useRef(
+    PanResponder.create({
+      onMoveShouldSetPanResponder: (_, gesture) => {
+        const { dx, dy } = gesture;
+        return Math.abs(dx) > 20 && Math.abs(dx) > Math.abs(dy);
+      },
+      onPanResponderRelease: (_, gesture) => {
+        const { dx } = gesture;
+        const currentIndex = order.indexOf(route.name);
+        if (dx < -50 && currentIndex < order.length - 1) {
+          navigation.navigate(order[currentIndex + 1]);
+        } else if (dx > 50 && currentIndex > 0) {
+          navigation.navigate(order[currentIndex - 1]);
+        }
+      },
+    })
+  ).current;
+
+  return responder.panHandlers;
+}

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -18,6 +18,7 @@ import { GameEngine } from 'react-native-game-engine';
 import Matter from 'matter-js';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import useSwipeTabs from '../navigation/useSwipeTabs';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';
 import { useHistory } from '../context/HistoryContext';
@@ -127,6 +128,7 @@ export default function GymScreen() {
   const [deleteMode, setDeleteMode] = useState(false);
   const [setCounts, setSetCounts] = useState([]);
   const { addEntry } = useHistory();
+  const panHandlers = useSwipeTabs();
 
   const engine = useRef(Matter.Engine.create({ enableSleeping: false }));
   const world = engine.current.world;
@@ -461,7 +463,7 @@ const toggleWorkout = useCallback(() => {
       resizeMode="cover"
     >
       <View style={{flex: 1}} pointerEvents="box-none">
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={styles.container} {...panHandlers}>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         {workouts[selectedWorkoutIdx] && (
           <View key={selectedWorkoutIdx} style={styles.workoutCard}>

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -6,6 +6,7 @@ import { useStats } from '../context/StatsContext';
 import { Picker } from '@react-native-picker/picker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { formatWeight } from '../utils/numberUtils';
+import useSwipeTabs from '../navigation/useSwipeTabs';
 
 const SPRITE = require('../../assets/AppSprite.png');
 
@@ -50,6 +51,7 @@ export default function HistoryScreen() {
   const { history } = useHistory();
   const { weekWeight, yearWeight, liftCount } = useStats();
   const [selectedEntry, setSelectedEntry] = useState(null);
+  const panHandlers = useSwipeTabs();
 
   // Pre-compute all months so users can swipe between them
   const months = monthOptions.map(opt => generateMonth(opt.year, opt.month));
@@ -86,7 +88,7 @@ export default function HistoryScreen() {
 
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} {...panHandlers}>
       <ScrollView
         horizontal
         pagingEnabled

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,15 +1,18 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, ImageBackground } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import useSwipeTabs from '../navigation/useSwipeTabs';
 
 export default function LoginScreen() {
   const [email, setEmail] = useState('');
+  const panHandlers = useSwipeTabs();
 
   return (
     <ImageBackground
       source={require('../../assets/loading.png')}
       style={styles.container}
       resizeMode="cover"
+      {...panHandlers}
     >
       <View style={styles.overlay}>
         <View style={styles.card}>

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -7,6 +7,7 @@ import ImageViewerModal from '../components/ImageViewerModal';
 import { useCharacter } from '../context/CharacterContext';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
+import useSwipeTabs from '../navigation/useSwipeTabs';
 import { Ionicons } from '@expo/vector-icons';
 
 const INITIAL_GALLERY = [];
@@ -25,6 +26,7 @@ export default function ProfileScreen() {
   const [viewerIndex, setViewerIndex] = useState(0);
   const navigation = useNavigation();
   const { level } = useCharacter();
+  const panHandlers = useSwipeTabs();
 
   const openViewer = index => {
     const items = tab === 'Gallery' ? galleryItems : privateItems;
@@ -70,7 +72,7 @@ export default function ProfileScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} {...panHandlers}>
       {/* Top Bar */}
       <View style={styles.topBar}>
         <TouchableOpacity onPress={() => navigation.navigate('Settings')}>


### PR DESCRIPTION
## Summary
- add `useSwipeTabs` hook for handling left/right pan gestures
- enable swipe navigation on Profile, Gym, History and Login screens

## Testing
- `npx expo start --no-interactive` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5c12e77c8328bd6d134faa61bccd