### PR TITLE
Add onboarding placeholder screens

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -4,6 +4,9 @@ import TabNavigator from './TabNavigator';
 import SettingsScreen from '../screens/SettingsScreen';
 import ActivityScreen from '../screens/ActivityScreen';
 import FriendsScreen from '../screens/FriendsScreen';
+import Onboarding1Screen from '../screens/Onboarding1Screen';
+import Onboarding2Screen from '../screens/Onboarding2Screen';
+import Onboarding3Screen from '../screens/Onboarding3Screen';
 
 const Stack = createNativeStackNavigator();
 
@@ -14,6 +17,9 @@ export default function RootNavigator() {
       <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen name="Activity" component={ActivityScreen} />
       <Stack.Screen name="Friends" component={FriendsScreen} />
+      <Stack.Screen name="Onboarding1" component={Onboarding1Screen} />
+      <Stack.Screen name="Onboarding2" component={Onboarding2Screen} />
+      <Stack.Screen name="Onboarding3" component={Onboarding3Screen} />
     </Stack.Navigator>
   );
 }

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -5,6 +5,9 @@ import GymScreen from '../screens/GymScreen';
 import HistoryScreen from '../screens/HistoryScreen';
 import LoginScreen from '../screens/LoginScreen';
 import ProfileScreen from '../screens/ProfileScreen';
+import Onboarding1Screen from '../screens/Onboarding1Screen';
+import Onboarding2Screen from '../screens/Onboarding2Screen';
+import Onboarding3Screen from '../screens/Onboarding3Screen';
 
 const Tab = createBottomTabNavigator();
 
@@ -23,6 +26,12 @@ export default function TabNavigator() {
             iconName = focused ? 'calendar' : 'calendar-outline';
           } else if (route.name === 'Login') {
             iconName = focused ? 'log-in' : 'log-in-outline';
+          } else if (
+            route.name === 'Onboarding1' ||
+            route.name === 'Onboarding2' ||
+            route.name === 'Onboarding3'
+          ) {
+            iconName = focused ? 'ellipse' : 'ellipse-outline';
           }
 
           return <Ionicons name={iconName} size={size} color={color} />;
@@ -36,6 +45,9 @@ export default function TabNavigator() {
       <Tab.Screen name="Gym" component={GymScreen} />
       <Tab.Screen name="History" component={HistoryScreen} />
       <Tab.Screen name="Login" component={LoginScreen} />
+      <Tab.Screen name="Onboarding1" component={Onboarding1Screen} />
+      <Tab.Screen name="Onboarding2" component={Onboarding2Screen} />
+      <Tab.Screen name="Onboarding3" component={Onboarding3Screen} />
     </Tab.Navigator>
   );
 }

--- a/src/screens/Onboarding1Screen.js
+++ b/src/screens/Onboarding1Screen.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+
+export default function Onboarding1Screen() {
+  return <SafeAreaView style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+});

--- a/src/screens/Onboarding2Screen.js
+++ b/src/screens/Onboarding2Screen.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+
+export default function Onboarding2Screen() {
+  return <SafeAreaView style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+});

--- a/src/screens/Onboarding3Screen.js
+++ b/src/screens/Onboarding3Screen.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+
+export default function Onboarding3Screen() {
+  return <SafeAreaView style={styles.container} />;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+});


### PR DESCRIPTION
## Summary
- create blank onboarding screens
- show onboarding screens in bottom tabs
- register onboarding screens in root stack

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b62b8b4308328895d0b5cb523f388