### PR TITLE
Adjust onboarding flow

### DIFF
--- a/src/screens/Onboarding1Screen.js
+++ b/src/screens/Onboarding1Screen.js
@@ -34,6 +34,8 @@ export default function Onboarding1Screen({ navigation }) {
         </View>
       </View>
 
+      <Text style={styles.header}>Build your gym buddy</Text>
+
       <Text style={styles.title}>Height & weight</Text>
       <Text style={styles.subtitle}>
         This will be used to calibrate your custom plan.
@@ -158,6 +160,12 @@ const styles = StyleSheet.create({
     height: '100%',
     backgroundColor: DARK_BLUE,
     borderRadius: 2,
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginTop: 20,
+    textAlign: 'center',
   },
   title: {
     fontSize: 28,

--- a/src/screens/Onboarding2Screen.js
+++ b/src/screens/Onboarding2Screen.js
@@ -17,7 +17,7 @@ export default function Onboarding2Screen({ navigation }) {
 
   const handleContinue = () => {
     const birthdate = `${month} ${day}, ${year}`;
-    navigation.navigate('Onboarding3', { birthdate });
+    navigation.navigate('Onboarding1', { birthdate });
   };
 
   const months = [


### PR DESCRIPTION
## Summary
- route the birthdate page back to onboarding step 1
- add a `Build your gym buddy` header on Onboarding1

## Testing
- `npm start -- --no-interactive` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6eebccf483289b7e4c2b11a77e5f