### PR TITLE
Add character selection and update avatar usage

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import { HistoryProvider } from './src/context/HistoryContext';
 import { StatsProvider } from './src/context/StatsContext';
 import { Asset } from 'expo-asset';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
+import { CHARACTER_IMAGES } from './src/data/characters';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -22,7 +23,10 @@ export default function App() {
 
   useEffect(() => {
     async function loadAssets() {
-      await Asset.loadAsync(Object.values(EQUIPMENT_IMAGES));
+      await Asset.loadAsync([
+        ...Object.values(EQUIPMENT_IMAGES),
+        ...Object.values(CHARACTER_IMAGES),
+      ]);
       setAssetsLoaded(true);
     }
     loadAssets();

--- a/src/components/ProfileModal.js
+++ b/src/components/ProfileModal.js
@@ -2,8 +2,12 @@ import React from 'react';
 import { View, Text, StyleSheet, Modal, TouchableOpacity, Dimensions } from 'react-native';
 import AvatarWithLevelBadge from './AvatarWithLevelBadge';
 import { Ionicons } from '@expo/vector-icons';
+import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_IMAGES } from '../data/characters';
 
 export default function ProfileModal({ isVisible, onClose, level = 1 }) {
+  const { characterId } = useCharacter();
+  const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
   return (
     <Modal
       visible={isVisible}
@@ -20,11 +24,7 @@ export default function ProfileModal({ isVisible, onClose, level = 1 }) {
 
           {/* Avatar */}
           <View style={styles.avatarContainer}>
-            <AvatarWithLevelBadge
-              source={require('../../assets/AppSprite.png')}
-              size={100}
-              level={level}
-            />
+            <AvatarWithLevelBadge source={sprite} size={100} level={level} />
           </View>
 
           {/* User Info */}

--- a/src/context/CharacterContext.js
+++ b/src/context/CharacterContext.js
@@ -5,14 +5,17 @@ import { getLevelInfo } from '../utils/levelUtils';
 const CharacterContext = createContext({
   exp: 0,
   level: 1,
+  characterId: 'GiraffeF',
+  setCharacterId: () => {},
   addExp: () => {},
 });
 
 export const CharacterProvider = ({ children }) => {
   const [exp, setExp] = useState(0);
   const [level, setLevel] = useState(1);
+  const [characterId, setCharacterId] = useState('GiraffeF');
 
-  // Load saved experience on mount
+  // Load saved experience and character on mount
   useEffect(() => {
     (async () => {
       try {
@@ -23,6 +26,10 @@ export const CharacterProvider = ({ children }) => {
             setExp(val);
             setLevel(getLevelInfo(val).level);
           }
+        }
+        const char = await AsyncStorage.getItem('characterId');
+        if (char) {
+          setCharacterId(char);
         }
       } catch {}
     })();
@@ -37,12 +44,19 @@ export const CharacterProvider = ({ children }) => {
     }
   }, [exp, level]);
 
+  // Persist character selection
+  useEffect(() => {
+    AsyncStorage.setItem('characterId', characterId);
+  }, [characterId]);
+
   const addExp = useCallback(amount => {
     setExp(e => e + amount);
   }, []);
 
   return (
-    <CharacterContext.Provider value={{ exp, level, addExp }}>
+    <CharacterContext.Provider
+      value={{ exp, level, characterId, setCharacterId, addExp }}
+    >
       {children}
     </CharacterContext.Provider>
   );

--- a/src/data/characters.js
+++ b/src/data/characters.js
@@ -1,0 +1,13 @@
+export const CHARACTER_IMAGES = {
+  GiraffeF: require('../../assets/characters/GiraffeF.png'),
+  GiraffeM: require('../../assets/characters/GiraffeM.png'),
+  GorillaF: require('../../assets/characters/GorillaF.png'),
+  GorillaM: require('../../assets/characters/GorillaM.png'),
+  OwlF: require('../../assets/characters/OwlF.png'),
+  OwlM: require('../../assets/characters/OwlM.png'),
+};
+
+export const CHARACTER_OPTIONS = Object.keys(CHARACTER_IMAGES).map(key => ({
+  id: key,
+  image: CHARACTER_IMAGES[key],
+}));

--- a/src/screens/GymGameScreen.js
+++ b/src/screens/GymGameScreen.js
@@ -5,8 +5,8 @@ import Matter from 'matter-js';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import TouchHandler from '../systems/TouchHandler';
 import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_IMAGES } from '../data/characters';
 
-const SPRITE = require('../../assets/AppSprite.png');
 const SPRITE_SIZE = 120;
 
 const Physics = (entities, { time }) => {
@@ -15,7 +15,7 @@ const Physics = (entities, { time }) => {
   return entities;
 };
 
-const Character = React.memo(({ body }) => {
+const Character = React.memo(({ body, sprite }) => {
   const width = body.bounds.max.x - body.bounds.min.x;
   const height = body.bounds.max.y - body.bounds.min.y;
   const x = body.position.x - width / 2;
@@ -23,7 +23,7 @@ const Character = React.memo(({ body }) => {
 
   return (
     <View style={[styles.character, { left: x, top: y, width, height }]}>
-      <Image source={SPRITE} style={styles.sprite} resizeMode="contain" />
+      <Image source={sprite} style={styles.sprite} resizeMode="contain" />
     </View>
   );
 });
@@ -45,7 +45,8 @@ export default function GymGameScreen() {
     };
   }, [world, characterBody]);
 
-  const { exp, level, addExp } = useCharacter();
+  const { exp, level, addExp, characterId } = useCharacter();
+  const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
 
   const addSet = useCallback(() => {
     addExp(1);
@@ -79,7 +80,7 @@ export default function GymGameScreen() {
         entities={entities}
         onEvent={onEvent}
       >
-        <Character body={characterBody} />
+        <Character body={characterBody} sprite={sprite} />
       </GameEngine>
       <View style={styles.buttonContainer}>
         <Button title="+ Set" onPress={addSet} />

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -29,8 +29,8 @@ import TouchHandler from '../systems/TouchHandler';
 import ExerciseSelector from '../components/ExerciseSelector';
 import EquipmentGrid from '../components/EquipmentGrid';
 import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_IMAGES } from '../data/characters';
 
-const SPRITE = require('../../assets/AppSprite.png');
 const SPRITE_SIZE = 120;
 
 const Physics = (entities, { time }) => {
@@ -39,7 +39,7 @@ const Physics = (entities, { time }) => {
   return entities;
 };
 
-const Character = React.memo(({ body }) => {
+const Character = React.memo(({ body, sprite }) => {
   const width = body.bounds.max.x - body.bounds.min.x;
   const height = body.bounds.max.y - body.bounds.min.y;
   const x = body.position.x - width / 2;
@@ -47,7 +47,7 @@ const Character = React.memo(({ body }) => {
 
   return (
     <View style={[styles.character, { left: x, top: y, width, height }]}> 
-      <Image source={SPRITE} style={styles.sprite} resizeMode="contain" />
+      <Image source={sprite} style={styles.sprite} resizeMode="contain" />
     </View>
   );
 });
@@ -154,7 +154,8 @@ export default function GymScreen() {
     };
   }, [world, characterBody]);
 
-  const { exp, level, addExp } = useCharacter();
+  const { exp, level, addExp, characterId } = useCharacter();
+  const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
   const { addWorkout } = useStats();
   const [showStatsModal, setShowStatsModal] = useState(false);
 
@@ -504,11 +505,7 @@ const toggleWorkout = useCallback(() => {
       </ScrollView>
       <View style={styles.expImageWrapper}>
         <TouchableOpacity onPress={showStats}>
-          <Image
-            source={require('../../assets/AppSprite.png')}
-            style={styles.expImage}
-            resizeMode="contain"
-          />
+          <Image source={sprite} style={styles.expImage} resizeMode="contain" />
         </TouchableOpacity>
       </View>
       <View style={styles.gameContainer}>
@@ -518,7 +515,7 @@ const toggleWorkout = useCallback(() => {
           style={styles.engine}
           onEvent={onEvent}
         >
-          <Character body={characterBody} />
+          <Character body={characterBody} sprite={sprite} />
         </GameEngine>
       </View>
       {workoutActive && (

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -7,8 +7,8 @@ import { Picker } from '@react-native-picker/picker';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { formatWeight } from '../utils/numberUtils';
 import useSwipeTabs from '../navigation/useSwipeTabs';
-
-const SPRITE = require('../../assets/AppSprite.png');
+import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_IMAGES } from '../data/characters';
 
 const MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -34,6 +34,9 @@ function generateMonth(year, month) {
 
 export default function HistoryScreen() {
   const today = new Date();
+
+  const { characterId } = useCharacter();
+  const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
 
   // Build the list of selectable months from April 2025 to today
   const earliest = new Date(2025, 3, 1); // April 2025
@@ -160,7 +163,7 @@ export default function HistoryScreen() {
                     {m.year === today.getFullYear() &&
                       m.month === today.getMonth() &&
                       day === today.getDate() && (
-                        <Image source={SPRITE} style={styles.sprite} />
+                        <Image source={sprite} style={styles.sprite} />
                       )}
                   </TouchableOpacity>
                 );

--- a/src/screens/Onboarding3Screen.js
+++ b/src/screens/Onboarding3Screen.js
@@ -1,23 +1,117 @@
-import React from 'react';
-import { SafeAreaView, StyleSheet, Text } from 'react-native';
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  SafeAreaView,
+  TouchableOpacity,
+  Image,
+  StyleSheet,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_OPTIONS } from '../data/characters';
 
-export default function Onboarding3Screen() {
+export default function Onboarding3Screen({ navigation }) {
+  const { characterId, setCharacterId } = useCharacter();
+  const [selected, setSelected] = useState(characterId);
+
+  const handleContinue = () => {
+    setCharacterId(selected);
+    navigation.navigate('Tabs');
+  };
+
   return (
     <SafeAreaView style={styles.container}>
+      <View style={styles.topBar}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Ionicons name="arrow-back" size={24} color="black" />
+        </TouchableOpacity>
+        <View style={styles.progressBar}>
+          <View style={styles.progress} />
+        </View>
+      </View>
       <Text style={styles.title}>Choose your gym buddy:</Text>
+      <View style={styles.options}>
+        {CHARACTER_OPTIONS.map(opt => (
+          <TouchableOpacity
+            key={opt.id}
+            style={[styles.option, selected === opt.id && styles.optionSelected]}
+            onPress={() => setSelected(opt.id)}
+          >
+            <Image source={opt.image} style={styles.avatar} />
+          </TouchableOpacity>
+        ))}
+      </View>
+      <TouchableOpacity style={styles.continueButton} onPress={handleContinue}>
+        <Text style={styles.continueText}>Continue</Text>
+      </TouchableOpacity>
     </SafeAreaView>
   );
 }
+
+const DARK = '#1C1B1F';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
     padding: 24,
+    justifyContent: 'space-between',
+  },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  progressBar: {
+    flex: 1,
+    height: 4,
+    backgroundColor: '#eee',
+    marginHorizontal: 12,
+    borderRadius: 2,
+  },
+  progress: {
+    width: '40%',
+    height: '100%',
+    backgroundColor: DARK,
+    borderRadius: 2,
   },
   title: {
     fontSize: 28,
     fontWeight: '600',
+    marginTop: 30,
+  },
+  options: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-around',
     marginTop: 20,
+  },
+  option: {
+    padding: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginBottom: 12,
+  },
+  optionSelected: {
+    borderColor: DARK,
+    backgroundColor: '#F0F0F0',
+  },
+  avatar: {
+    width: 80,
+    height: 80,
+    resizeMode: 'contain',
+  },
+  continueButton: {
+    backgroundColor: DARK,
+    borderRadius: 32,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginBottom: 30,
+  },
+  continueText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '500',
   },
 });

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -5,6 +5,7 @@ import * as ImagePicker from 'expo-image-picker';
 import AvatarWithLevelBadge from '../components/AvatarWithLevelBadge';
 import ImageViewerModal from '../components/ImageViewerModal';
 import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_IMAGES } from '../data/characters';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 import useSwipeTabs from '../navigation/useSwipeTabs';
@@ -25,7 +26,8 @@ export default function ProfileScreen() {
   const [viewerVisible, setViewerVisible] = useState(false);
   const [viewerIndex, setViewerIndex] = useState(0);
   const navigation = useNavigation();
-  const { level } = useCharacter();
+  const { level, characterId } = useCharacter();
+  const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
   const panHandlers = useSwipeTabs();
 
   const openViewer = index => {
@@ -87,11 +89,7 @@ export default function ProfileScreen() {
       <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
         {/* Profile Info */}
         <View style={styles.profileInfo}>
-          <AvatarWithLevelBadge
-            source={require('../../assets/AppSprite.png')}
-            size={72}
-            level={level}
-          />
+          <AvatarWithLevelBadge source={sprite} size={72} level={level} />
           <Text style={styles.username}>vscotest40</Text>
           <View style={styles.profileActions}>
             <TouchableOpacity style={styles.editBtn}>


### PR DESCRIPTION
## Summary
- allow onboarding step 3 to select character avatar
- persist selected avatar in context
- load avatar assets on app startup
- display chosen avatar throughout the app

## Testing
- `npm install`
- `npm start` *(fails: waiting for Metro)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b722d05e0832884ed8a07fb2a5919