### PR TITLE
Add background selection after character creation

### DIFF
--- a/App.js
+++ b/App.js
@@ -8,6 +8,7 @@ import RootNavigator from './src/navigation/RootNavigator';
 import { CharacterProvider } from './src/context/CharacterContext';
 import { HistoryProvider } from './src/context/HistoryContext';
 import { StatsProvider } from './src/context/StatsContext';
+import { BackgroundProvider } from './src/context/BackgroundContext';
 import { Asset } from 'expo-asset';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
 import { CHARACTER_IMAGES } from './src/data/characters';
@@ -46,9 +47,11 @@ export default function App() {
         <HistoryProvider>
           <StatsProvider>
             <CharacterProvider>
-              <NavigationContainer>
-                <RootNavigator />
-              </NavigationContainer>
+              <BackgroundProvider>
+                <NavigationContainer>
+                  <RootNavigator />
+                </NavigationContainer>
+              </BackgroundProvider>
             </CharacterProvider>
           </StatsProvider>
         </HistoryProvider>

--- a/src/context/BackgroundContext.js
+++ b/src/context/BackgroundContext.js
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const BackgroundContext = createContext({
+  background: 'newschool',
+  setBackground: () => {},
+});
+
+export const BackgroundProvider = ({ children }) => {
+  const [background, setBackground] = useState('newschool');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('background');
+        if (stored) {
+          setBackground(stored);
+        }
+      } catch {}
+    })();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem('background', background);
+  }, [background]);
+
+  return (
+    <BackgroundContext.Provider value={{ background, setBackground }}>
+      {children}
+    </BackgroundContext.Provider>
+  );
+};
+
+export const useBackground = () => useContext(BackgroundContext);

--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -7,6 +7,7 @@ import FriendsScreen from '../screens/FriendsScreen';
 import Onboarding1Screen from '../screens/Onboarding1Screen';
 import Onboarding2Screen from '../screens/Onboarding2Screen';
 import Onboarding3Screen from '../screens/Onboarding3Screen';
+import Onboarding4Screen from '../screens/Onboarding4Screen';
 import GenderScreen from '../screens/GenderScreen';
 
 const Stack = createNativeStackNavigator();
@@ -22,6 +23,7 @@ export default function RootNavigator() {
       <Stack.Screen name="Onboarding1" component={Onboarding1Screen} />
       <Stack.Screen name="Onboarding2" component={Onboarding2Screen} />
       <Stack.Screen name="Onboarding3" component={Onboarding3Screen} />
+      <Stack.Screen name="Onboarding4" component={Onboarding4Screen} />
     </Stack.Navigator>
   );
 }

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -8,6 +8,7 @@ import ProfileScreen from '../screens/ProfileScreen';
 import Onboarding1Screen from '../screens/Onboarding1Screen';
 import Onboarding2Screen from '../screens/Onboarding2Screen';
 import Onboarding3Screen from '../screens/Onboarding3Screen';
+import Onboarding4Screen from '../screens/Onboarding4Screen';
 
 const Tab = createBottomTabNavigator();
 
@@ -29,7 +30,8 @@ export default function TabNavigator() {
           } else if (
             route.name === 'Onboarding1' ||
             route.name === 'Onboarding2' ||
-            route.name === 'Onboarding3'
+            route.name === 'Onboarding3' ||
+            route.name === 'Onboarding4'
           ) {
             iconName = focused ? 'ellipse' : 'ellipse-outline';
           }
@@ -48,6 +50,7 @@ export default function TabNavigator() {
       <Tab.Screen name="Onboarding1" component={Onboarding1Screen} />
       <Tab.Screen name="Onboarding2" component={Onboarding2Screen} />
       <Tab.Screen name="Onboarding3" component={Onboarding3Screen} />
+      <Tab.Screen name="Onboarding4" component={Onboarding4Screen} />
     </Tab.Navigator>
   );
 }

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -30,6 +30,9 @@ import ExerciseSelector from '../components/ExerciseSelector';
 import EquipmentGrid from '../components/EquipmentGrid';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_IMAGES } from '../data/characters';
+import { useBackground } from '../context/BackgroundContext';
+import oldBG from '../../assets/backgrounds/APP_BG_oldschool.png';
+import newBG from '../../assets/backgrounds/APP_BG_newschool.png';
 
 const SPRITE_SIZE = 120;
 
@@ -155,6 +158,7 @@ export default function GymScreen() {
   }, [world, characterBody]);
 
   const { exp, level, addExp, characterId } = useCharacter();
+  const { background } = useBackground();
   const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
   const { addWorkout } = useStats();
   const [showStatsModal, setShowStatsModal] = useState(false);
@@ -457,9 +461,11 @@ const toggleWorkout = useCallback(() => {
     [currentExercises]
   );
 
+  const bgSource = background === 'oldschool' ? oldBG : newBG;
+
   return (
     <ImageBackground
-      source={require('../../assets/backgrounds/APP_BG_newschool.png')}
+      source={bgSource}
       style={styles.background}
       resizeMode="cover"
     >

--- a/src/screens/Onboarding4Screen.js
+++ b/src/screens/Onboarding4Screen.js
@@ -1,23 +1,15 @@
 import React, { useState } from 'react';
-import {
-  View,
-  Text,
-  SafeAreaView,
-  TouchableOpacity,
-  Image,
-  StyleSheet,
-} from 'react-native';
+import { View, Text, SafeAreaView, TouchableOpacity, Image, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { useCharacter } from '../context/CharacterContext';
-import { CHARACTER_OPTIONS } from '../data/characters';
+import { useBackground } from '../context/BackgroundContext';
 
-export default function Onboarding3Screen({ navigation }) {
-  const { characterId, setCharacterId } = useCharacter();
-  const [selected, setSelected] = useState(characterId);
+export default function Onboarding4Screen({ navigation }) {
+  const { background, setBackground } = useBackground();
+  const [selected, setSelected] = useState(background);
 
   const handleContinue = () => {
-    setCharacterId(selected);
-    navigation.navigate('Onboarding4');
+    setBackground(selected);
+    navigation.navigate('Gym');
   };
 
   return (
@@ -30,17 +22,31 @@ export default function Onboarding3Screen({ navigation }) {
           <View style={styles.progress} />
         </View>
       </View>
+
       <View style={styles.options}>
-        {CHARACTER_OPTIONS.map(opt => (
-          <TouchableOpacity
-            key={opt.id}
-            style={[styles.option, selected === opt.id && styles.optionSelected]}
-            onPress={() => setSelected(opt.id)}
-          >
-            <Image source={opt.image} style={styles.avatar} />
-          </TouchableOpacity>
-        ))}
+        <TouchableOpacity
+          style={[styles.option, selected === 'oldschool' && styles.optionSelected]}
+          onPress={() => setSelected('oldschool')}
+        >
+          <Image
+            source={require('../../assets/backgrounds/APP_BG_oldschool.png')}
+            style={styles.image}
+          />
+          <Text style={styles.label}>Oldschool</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.option, selected === 'newschool' && styles.optionSelected]}
+          onPress={() => setSelected('newschool')}
+        >
+          <Image
+            source={require('../../assets/backgrounds/APP_BG_newschool.png')}
+            style={styles.image}
+          />
+          <Text style={styles.label}>Newschool</Text>
+        </TouchableOpacity>
       </View>
+
       <TouchableOpacity style={styles.continueButton} onPress={handleContinue}>
         <Text style={styles.continueText}>Continue</Text>
       </TouchableOpacity>
@@ -69,37 +75,36 @@ const styles = StyleSheet.create({
     borderRadius: 2,
   },
   progress: {
-    width: '40%',
+    width: '50%',
     height: '100%',
     backgroundColor: DARK,
     borderRadius: 2,
   },
-  title: {
-    fontSize: 28,
-    fontWeight: '600',
-    marginTop: 30,
-  },
   options: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
     justifyContent: 'space-around',
     marginTop: 20,
   },
   option: {
+    alignItems: 'center',
     padding: 8,
     borderRadius: 12,
     borderWidth: 1,
     borderColor: '#ccc',
-    marginBottom: 12,
   },
   optionSelected: {
     borderColor: DARK,
     backgroundColor: '#F0F0F0',
   },
-  avatar: {
-    width: 80,
-    height: 80,
-    resizeMode: 'contain',
+  image: {
+    width: 120,
+    height: 120,
+    resizeMode: 'cover',
+    borderRadius: 8,
+  },
+  label: {
+    marginTop: 8,
+    fontSize: 14,
   },
   continueButton: {
     backgroundColor: DARK,


### PR DESCRIPTION
## Summary
- add `BackgroundContext` for persisting theme choice
- wrap app in `BackgroundProvider`
- create `Onboarding4Screen` to pick between oldschool and newschool
- navigate from character selection to new screen
- update navigators with the new screen
- render gym background based on selected theme

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca8b6002483288cd97333fbfea5ef