### PR TITLE
Fix onboarding navigation to gym tab

### DIFF
--- a/src/screens/Onboarding4Screen.js
+++ b/src/screens/Onboarding4Screen.js
@@ -9,7 +9,8 @@ export default function Onboarding4Screen({ navigation }) {
 
   const handleContinue = () => {
     setBackground(selected);
-    navigation.navigate('Gym');
+    // Navigate to the Gym tab inside the Tab navigator
+    navigation.navigate('Tabs', { screen: 'Gym' });
   };
 
   return (


### PR DESCRIPTION
## Summary
- navigate to the Gym screen through the nested Tab navigator

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(starts Metro bundler)*

------
https://chatgpt.com/codex/tasks/task_e_685cab9f88148328bddcc851c45ce544