### PR TITLE
Add level-up celebration

### DIFF
--- a/src/components/LevelUpModal.js
+++ b/src/components/LevelUpModal.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef } from 'react';
+import { Modal, View, Text, StyleSheet, Animated } from 'react-native';
+import * as Progress from 'react-native-progress';
+
+const AnimatedBar = Animated.createAnimatedComponent(Progress.Bar);
+
+export default function LevelUpModal({ visible, onClose }) {
+  const progress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (visible) {
+      progress.setValue(0);
+      Animated.sequence([
+        Animated.timing(progress, {
+          toValue: 1,
+          duration: 800,
+          useNativeDriver: false,
+        }),
+        Animated.timing(progress, {
+          toValue: 0,
+          duration: 300,
+          useNativeDriver: false,
+        }),
+      ]).start(({ finished }) => {
+        if (finished && onClose) {
+          onClose();
+        }
+      });
+    }
+  }, [visible, onClose, progress]);
+
+  return (
+    <Modal transparent visible={visible} animationType="fade">
+      <View style={styles.overlay}>
+        <View style={styles.box}>
+          <Text style={styles.text}>Good Work!!!</Text>
+          <AnimatedBar
+            progress={progress}
+            width={200}
+            height={12}
+            color="#4CAF50"
+            unfilledColor="#eee"
+            borderWidth={0}
+          />
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  box: {
+    backgroundColor: '#fff',
+    padding: 20,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 16,
+    color: '#222',
+  },
+});

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -28,6 +28,7 @@ import ExpCircle from '../components/ExpCircle';
 import TouchHandler from '../systems/TouchHandler';
 import ExerciseSelector from '../components/ExerciseSelector';
 import EquipmentGrid from '../components/EquipmentGrid';
+import LevelUpModal from '../components/LevelUpModal';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_IMAGES } from '../data/characters';
 import { useBackground } from '../context/BackgroundContext';
@@ -162,6 +163,8 @@ export default function GymScreen() {
   const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
   const { addWorkout } = useStats();
   const [showStatsModal, setShowStatsModal] = useState(false);
+  const [showLevelUpModal, setShowLevelUpModal] = useState(false);
+  const [startLevel, setStartLevel] = useState(level);
 
   const showStats = useCallback(() => {
     setShowStatsModal(true);
@@ -423,12 +426,16 @@ const toggleWorkout = useCallback(() => {
         addWorkout(weight, true);
       }
       setSetCounts([]);
+      if (level > startLevel) {
+        setShowLevelUpModal(true);
+      }
     } else if (next) {
       setSetCounts(currentExercises.map(() => 0));
+      setStartLevel(level);
     }
     return next;
   });
-}, [workouts, selectedWorkoutIdx, currentExercises, setCounts, addEntry, addWorkout]);
+}, [workouts, selectedWorkoutIdx, currentExercises, setCounts, addEntry, addWorkout, level, startLevel]);
 
   useEffect(() => {
     if (workoutActive) {
@@ -711,6 +718,11 @@ const toggleWorkout = useCallback(() => {
           </View>
         </View>
       </Modal>
+
+      <LevelUpModal
+        visible={showLevelUpModal}
+        onClose={() => setShowLevelUpModal(false)}
+      />
 
       {/* Stats Modal */}
       <Modal visible={showStatsModal} transparent animationType="fade">


### PR DESCRIPTION
## Summary
- add `LevelUpModal` to animate EXP bar and show "Good Work!!!"
- trigger modal at the end of a workout when the user levels up

## Testing
- `npm test` *(fails: Missing script)*
- `npm start -- --help` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cad76c77c832880ec625ec6bcfae5