### PR TITLE
Show level badge and EXP bar in gym screen

### DIFF
--- a/src/components/ExpBar.js
+++ b/src/components/ExpBar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import * as Progress from 'react-native-progress';
+import { getLevelInfo } from '../utils/levelUtils';
+
+export default function ExpBar({ exp, width = 150, height = 10 }) {
+  const { expThisLevel, expForNext } = getLevelInfo(exp);
+  const progress = expThisLevel / expForNext;
+  return (
+    <Progress.Bar
+      progress={progress}
+      width={width}
+      height={height}
+      color="#4CAF50"
+      unfilledColor="#eee"
+      borderWidth={0}
+    />
+  );
+}

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -25,6 +25,8 @@ import { useHistory } from '../context/HistoryContext';
 import { useStats } from '../context/StatsContext';
 import { toDateKey } from '../utils/dateUtils';
 import ExpCircle from '../components/ExpCircle';
+import AvatarWithLevelBadge from '../components/AvatarWithLevelBadge';
+import ExpBar from '../components/ExpBar';
 import TouchHandler from '../systems/TouchHandler';
 import ExerciseSelector from '../components/ExerciseSelector';
 import EquipmentGrid from '../components/EquipmentGrid';
@@ -511,8 +513,17 @@ const toggleWorkout = useCallback(() => {
       </ScrollView>
       <View style={styles.expImageWrapper}>
         <TouchableOpacity onPress={showStats}>
-          <Image source={sprite} style={styles.expImage} resizeMode="contain" />
+          <AvatarWithLevelBadge
+            source={sprite}
+            size={150}
+            level={workoutActive ? null : level}
+          />
         </TouchableOpacity>
+        {!workoutActive && (
+          <View style={styles.expBar}>
+            <ExpBar exp={exp} />
+          </View>
+        )}
       </View>
       <View style={styles.gameContainer}>
         <GameEngine
@@ -931,6 +942,9 @@ const styles = StyleSheet.create({
   expImage: {
     width: 150,
     height: 150,
+  },
+  expBar: {
+    marginTop: 8,
   },
   workoutToggleBtn: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- add `ExpBar` component for displaying EXP progress
- show level badge on avatar and EXP bar below it in the gym screen

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: expo not found)*


------
https://chatgpt.com/codex/tasks/task_e_685cad23059c83288baa4a7d52d71028