### PR TITLE
Fix wheel picker render item

### DIFF
--- a/src/screens/Onboarding1Screen.js
+++ b/src/screens/Onboarding1Screen.js
@@ -71,8 +71,8 @@ export default function Onboarding1Screen({ navigation }) {
                 }))}
                 initialSelectedIndex={feetIndex}
                 onChange={({ index }) => setFeetIndex(index)}
-                renderItem={({ item }) => (
-                  <Text style={styles.pickerItem}>{item.label}</Text>
+                renderItem={({ label }) => (
+                  <Text style={styles.pickerItem}>{label}</Text>
                 )}
               />
             </View>
@@ -87,8 +87,8 @@ export default function Onboarding1Screen({ navigation }) {
                 }))}
                 initialSelectedIndex={inchIndex}
                 onChange={({ index }) => setInchIndex(index)}
-                renderItem={({ item }) => (
-                  <Text style={styles.pickerItem}>{item.label}</Text>
+                renderItem={({ label }) => (
+                  <Text style={styles.pickerItem}>{label}</Text>
                 )}
               />
             </View>
@@ -105,8 +105,8 @@ export default function Onboarding1Screen({ navigation }) {
               }))}
               initialSelectedIndex={cmIndex}
               onChange={({ index }) => setCmIndex(index)}
-              renderItem={({ item }) => (
-                <Text style={styles.pickerItem}>{item.label}</Text>
+              renderItem={({ label }) => (
+                <Text style={styles.pickerItem}>{label}</Text>
               )}
             />
           </View>
@@ -123,8 +123,8 @@ export default function Onboarding1Screen({ navigation }) {
             })}
             initialSelectedIndex={weightIndex}
             onChange={({ index }) => setWeightIndex(index)}
-            renderItem={({ item }) => (
-              <Text style={styles.pickerItem}>{item.label}</Text>
+            renderItem={({ label }) => (
+              <Text style={styles.pickerItem}>{label}</Text>
             )}
           />
         </View>

--- a/src/screens/Onboarding2Screen.js
+++ b/src/screens/Onboarding2Screen.js
@@ -68,8 +68,8 @@ export default function Onboarding2Screen({ navigation }) {
             items={months.map((m, i) => ({ label: m, value: i }))}
             initialSelectedIndex={monthIndex}
             onChange={({ index }) => setMonthIndex(index)}
-            renderItem={({ item }) => (
-              <Text style={styles.pickerItem}>{item.label}</Text>
+            renderItem={({ label }) => (
+              <Text style={styles.pickerItem}>{label}</Text>
             )}
           />
         </View>
@@ -81,8 +81,8 @@ export default function Onboarding2Screen({ navigation }) {
             items={days.map((d, i) => ({ label: d, value: i }))}
             initialSelectedIndex={dayIndex}
             onChange={({ index }) => setDayIndex(index)}
-            renderItem={({ item }) => (
-              <Text style={styles.pickerItem}>{item.label}</Text>
+            renderItem={({ label }) => (
+              <Text style={styles.pickerItem}>{label}</Text>
             )}
           />
         </View>
@@ -94,8 +94,8 @@ export default function Onboarding2Screen({ navigation }) {
             items={years.map((y, i) => ({ label: y, value: i }))}
             initialSelectedIndex={yearIndex}
             onChange={({ index }) => setYearIndex(index)}
-            renderItem={({ item }) => (
-              <Text style={styles.pickerItem}>{item.label}</Text>
+            renderItem={({ label }) => (
+              <Text style={styles.pickerItem}>{label}</Text>
             )}
           />
         </View>


### PR DESCRIPTION
## Summary
- fix renderItem parameter for WheelPickerExpo on onboarding screens

## Testing
- `npm install`
- `npm start` *(started Metro Bundler)*

------
https://chatgpt.com/codex/tasks/task_e_685cae90dc588328b17551ddffef8569