### PR TITLE
Add pet naming with profanity filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/bottom-tabs": "^7.3.14",
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.16",
+        "bad-words": "^4.0.0",
         "expo": "~53.0.11",
         "expo-av": "^15.1.6",
         "expo-image-picker": "^16.1.4",
@@ -4182,6 +4183,24 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/bad-words": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bad-words/-/bad-words-4.0.0.tgz",
+      "integrity": "sha512-fLjG/I0N3I7xhurqGnGitSRD10UeEE63a7hyXtutQDpxo4+Eal+i7veWeZxZJPNtsl6X1mUIoWPwt8gQ7NMQUw==",
+      "license": "MIT",
+      "dependencies": {
+        "badwords-list": "^2.0.1-4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/badwords-list": {
+      "version": "2.0.1-4",
+      "resolved": "https://registry.npmjs.org/badwords-list/-/badwords-list-2.0.1-4.tgz",
+      "integrity": "sha512-FxfZUp7B9yCnesNtFQS9v6PvZdxTYa14Q60JR6vhjdQdWI4naTjJIyx22JzoER8ooeT8SAAKoHLjKfCV7XgYUQ==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/bottom-tabs": "^7.3.14",
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.16",
+    "bad-words": "^4.0.0",
     "expo": "~53.0.11",
     "expo-av": "^15.1.6",
     "expo-image-picker": "^16.1.4",

--- a/src/context/CharacterContext.js
+++ b/src/context/CharacterContext.js
@@ -6,7 +6,9 @@ const CharacterContext = createContext({
   exp: 0,
   level: 1,
   characterId: 'GiraffeF',
+  petName: '',
   setCharacterId: () => {},
+  setPetName: () => {},
   addExp: () => {},
 });
 
@@ -14,8 +16,9 @@ export const CharacterProvider = ({ children }) => {
   const [exp, setExp] = useState(0);
   const [level, setLevel] = useState(1);
   const [characterId, setCharacterId] = useState('GiraffeF');
+  const [petName, setPetName] = useState('');
 
-  // Load saved experience and character on mount
+  // Load saved experience, character and pet name on mount
   useEffect(() => {
     (async () => {
       try {
@@ -30,6 +33,10 @@ export const CharacterProvider = ({ children }) => {
         const char = await AsyncStorage.getItem('characterId');
         if (char) {
           setCharacterId(char);
+        }
+        const name = await AsyncStorage.getItem('petName');
+        if (name) {
+          setPetName(name);
         }
       } catch {}
     })();
@@ -49,13 +56,18 @@ export const CharacterProvider = ({ children }) => {
     AsyncStorage.setItem('characterId', characterId);
   }, [characterId]);
 
+  // Persist pet name
+  useEffect(() => {
+    AsyncStorage.setItem('petName', petName);
+  }, [petName]);
+
   const addExp = useCallback(amount => {
     setExp(e => e + amount);
   }, []);
 
   return (
     <CharacterContext.Provider
-      value={{ exp, level, characterId, setCharacterId, addExp }}
+      value={{ exp, level, characterId, petName, setCharacterId, setPetName, addExp }}
     >
       {children}
     </CharacterContext.Provider>

--- a/src/screens/Onboarding3Screen.js
+++ b/src/screens/Onboarding3Screen.js
@@ -6,17 +6,27 @@ import {
   TouchableOpacity,
   Image,
   StyleSheet,
+  TextInput,
+  Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_OPTIONS } from '../data/characters';
+import Filter from 'bad-words';
 
 export default function Onboarding3Screen({ navigation }) {
-  const { characterId, setCharacterId } = useCharacter();
+  const { characterId, petName, setCharacterId, setPetName } = useCharacter();
   const [selected, setSelected] = useState(characterId);
+  const [name, setName] = useState(petName);
+  const filter = new Filter();
 
   const handleContinue = () => {
+    if (!name || filter.isProfane(name)) {
+      Alert.alert('Invalid Name', 'Please choose an appropriate pet name.');
+      return;
+    }
     setCharacterId(selected);
+    setPetName(name.trim());
     navigation.navigate('Onboarding4');
   };
 
@@ -41,6 +51,13 @@ export default function Onboarding3Screen({ navigation }) {
           </TouchableOpacity>
         ))}
       </View>
+      <TextInput
+        style={styles.input}
+        placeholder="Pet Name"
+        placeholderTextColor="#888"
+        value={name}
+        onChangeText={setName}
+      />
       <TouchableOpacity style={styles.continueButton} onPress={handleContinue}>
         <Text style={styles.continueText}>Continue</Text>
       </TouchableOpacity>
@@ -100,6 +117,14 @@ const styles = StyleSheet.create({
     width: 80,
     height: 80,
     resizeMode: 'contain',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 8,
+    marginBottom: 12,
+    color: '#222',
   },
   continueButton: {
     backgroundColor: DARK,


### PR DESCRIPTION
## Summary
- add `bad-words` dependency
- store `petName` in `CharacterContext`
- ask for pet name on character selection screen and validate with profanity filter

## Testing
- `npm start -- --max-workers=1` *(fails: waiting for Expo server)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685caf31bcb883289d04e3b2927aa8f8