### PR TITLE
Show pet name and personalize level up

### DIFF
--- a/src/components/LevelUpModal.js
+++ b/src/components/LevelUpModal.js
@@ -4,7 +4,7 @@ import * as Progress from 'react-native-progress';
 
 const AnimatedBar = Animated.createAnimatedComponent(Progress.Bar);
 
-export default function LevelUpModal({ visible, onClose }) {
+export default function LevelUpModal({ visible, onClose, petName }) {
   const progress = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
@@ -33,7 +33,9 @@ export default function LevelUpModal({ visible, onClose }) {
     <Modal transparent visible={visible} animationType="fade">
       <View style={styles.overlay}>
         <View style={styles.box}>
-          <Text style={styles.text}>Good Work!!!</Text>
+          <Text style={styles.text}>
+            {`Good Luck, ${petName || 'your pet'} is getting stronger!`}
+          </Text>
           <AnimatedBar
             progress={progress}
             width={200}

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -45,14 +45,15 @@ const Physics = (entities, { time }) => {
   return entities;
 };
 
-const Character = React.memo(({ body, sprite }) => {
+const Character = React.memo(({ body, sprite, petName }) => {
   const width = body.bounds.max.x - body.bounds.min.x;
   const height = body.bounds.max.y - body.bounds.min.y;
   const x = body.position.x - width / 2;
   const y = body.position.y - height / 2;
 
   return (
-    <View style={[styles.character, { left: x, top: y, width, height }]}> 
+    <View style={[styles.character, { left: x, top: y, width, height }]}>
+      {petName ? <Text style={styles.petName}>{petName}</Text> : null}
       <Image source={sprite} style={styles.sprite} resizeMode="contain" />
     </View>
   );
@@ -160,7 +161,7 @@ export default function GymScreen() {
     };
   }, [world, characterBody]);
 
-  const { exp, level, addExp, characterId } = useCharacter();
+  const { exp, level, addExp, characterId, petName } = useCharacter();
   const { background } = useBackground();
   const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GiraffeF;
   const { addWorkout } = useStats();
@@ -539,7 +540,7 @@ const toggleWorkout = useCallback(() => {
           style={styles.engine}
           onEvent={onEvent}
         >
-          <Character body={characterBody} sprite={sprite} />
+          <Character body={characterBody} sprite={sprite} petName={petName} />
         </GameEngine>
       </View>
       {workoutActive && (
@@ -733,6 +734,7 @@ const toggleWorkout = useCallback(() => {
       <LevelUpModal
         visible={showLevelUpModal}
         onClose={() => setShowLevelUpModal(false)}
+        petName={petName}
       />
 
       {/* Stats Modal */}
@@ -903,6 +905,12 @@ const styles = StyleSheet.create({
     position: 'absolute',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  petName: {
+    position: 'absolute',
+    top: -20,
+    fontWeight: '700',
+    color: '#222',
   },
   sprite: {
     width: '100%',


### PR DESCRIPTION
## Summary
- show the pet's name above the avatar in the gym
- personalize level up modal with pet name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cb410c4908328abb1bb689e3175e2