### PR TITLE
Fix Onboarding3Screen character selector bug

### DIFF
--- a/src/screens/Onboarding3Screen.js
+++ b/src/screens/Onboarding3Screen.js
@@ -12,7 +12,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_OPTIONS } from '../data/characters';
-import Filter from 'bad-words';
+import { Filter } from 'bad-words';
 
 export default function Onboarding3Screen({ navigation }) {
   const { characterId, petName, setCharacterId, setPetName } = useCharacter();
@@ -44,7 +44,10 @@ export default function Onboarding3Screen({ navigation }) {
         {CHARACTER_OPTIONS.map(opt => (
           <TouchableOpacity
             key={opt.id}
-            style={[styles.option, selected === opt.id && styles.optionSelected]}
+            style={[
+              styles.option,
+              selected === opt.id && styles.optionSelected,
+            ]}
             onPress={() => setSelected(opt.id)}
           >
             <Image source={opt.image} style={styles.avatar} />


### PR DESCRIPTION
## Summary
- use named export for Filter from bad-words
- correct style prop formatting in Onboarding3Screen

## Testing
- `npm install`
- `npm start -- --max-workers=1 --non-interactive` *(terminated after server start)*


------
https://chatgpt.com/codex/tasks/task_e_685cb3d0420083289571f398edbd8807