### PR TITLE
Remove onboarding flow

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -4,11 +4,6 @@ import TabNavigator from './TabNavigator';
 import SettingsScreen from '../screens/SettingsScreen';
 import ActivityScreen from '../screens/ActivityScreen';
 import FriendsScreen from '../screens/FriendsScreen';
-import Onboarding1Screen from '../screens/Onboarding1Screen';
-import Onboarding2Screen from '../screens/Onboarding2Screen';
-import Onboarding3Screen from '../screens/Onboarding3Screen';
-import Onboarding4Screen from '../screens/Onboarding4Screen';
-import GenderScreen from '../screens/GenderScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -19,11 +14,6 @@ export default function RootNavigator() {
       <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen name="Activity" component={ActivityScreen} />
       <Stack.Screen name="Friends" component={FriendsScreen} />
-      <Stack.Screen name="Gender" component={GenderScreen} />
-      <Stack.Screen name="Onboarding1" component={Onboarding1Screen} />
-      <Stack.Screen name="Onboarding2" component={Onboarding2Screen} />
-      <Stack.Screen name="Onboarding3" component={Onboarding3Screen} />
-      <Stack.Screen name="Onboarding4" component={Onboarding4Screen} />
     </Stack.Navigator>
   );
 }

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -15,7 +15,7 @@ const OnboardingScreen = ({ navigation }) => {
       </View>
       <TouchableOpacity
         style={styles.getStartedButton}
-        onPress={() => navigation.navigate('Gender')}
+        onPress={() => {}}
       >
         <Text style={styles.buttonText}>Get Started</Text>
       </TouchableOpacity>


### PR DESCRIPTION
## Summary
- remove onboarding screens from navigation
- stop `Get Started` button from opening onboarding

## Testing
- `npm start` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e1802ac3083289da70c2ce5b1c134