### PR TITLE
Add comic intro sequence

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,6 +12,7 @@ import { BackgroundProvider } from './src/context/BackgroundContext';
 import { Asset } from 'expo-asset';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
 import { CHARACTER_IMAGES } from './src/data/characters';
+import { COMIC_IMAGES } from './src/data/comicPages';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -27,6 +28,7 @@ export default function App() {
       await Asset.loadAsync([
         ...Object.values(EQUIPMENT_IMAGES),
         ...Object.values(CHARACTER_IMAGES),
+        ...COMIC_IMAGES,
       ]);
       setAssetsLoaded(true);
     }

--- a/src/data/comicPages.js
+++ b/src/data/comicPages.js
@@ -1,0 +1,7 @@
+export const COMIC_IMAGES = [
+  require('../../assets/Comic/page1Door.png'),
+  require('../../assets/Comic/page2Gorilla.png'),
+  require('../../assets/Comic/Page3Gorilla.png'),
+  require('../../assets/Comic/Page4Gorilla.png'),
+  require('../../assets/Comic/Page5Gorilla.png'),
+];

--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -4,12 +4,17 @@ import TabNavigator from './TabNavigator';
 import SettingsScreen from '../screens/SettingsScreen';
 import ActivityScreen from '../screens/ActivityScreen';
 import FriendsScreen from '../screens/FriendsScreen';
+import ComicScreen from '../screens/ComicScreen';
 
 const Stack = createNativeStackNavigator();
 
 export default function RootNavigator() {
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{ headerShown: false }}
+      initialRouteName="Comic"
+    >
+      <Stack.Screen name="Comic" component={ComicScreen} />
       <Stack.Screen name="Tabs" component={TabNavigator} />
       <Stack.Screen name="Settings" component={SettingsScreen} />
       <Stack.Screen name="Activity" component={ActivityScreen} />

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, useWindowDimensions, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -14,9 +14,22 @@ const routes = [
   { key: 'History', icon: 'calendar' },
 ];
 
-export default function TabNavigator() {
+export default function TabNavigator({ route }) {
   const layout = useWindowDimensions();
-  const [index, setIndex] = useState(0);
+  const initialRoute = route?.params?.screen;
+  const initialIndex = initialRoute === 'Gym' ? 1 : initialRoute === 'History' ? 2 : 0;
+  const [index, setIndex] = useState(initialIndex);
+
+  useEffect(() => {
+    const newRoute = route?.params?.screen;
+    if (newRoute === 'Gym') {
+      setIndex(1);
+    } else if (newRoute === 'History') {
+      setIndex(2);
+    } else if (newRoute === 'Profile') {
+      setIndex(0);
+    }
+  }, [route?.params?.screen]);
 
   const renderScene = SceneMap({
     Profile: ProfileScreen,

--- a/src/screens/ComicScreen.js
+++ b/src/screens/ComicScreen.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { TouchableOpacity, Image, StyleSheet, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { COMIC_IMAGES } from '../data/comicPages';
+
+export default function ComicScreen({ navigation }) {
+  const [page, setPage] = useState(0);
+
+  const handlePress = () => {
+    if (page < COMIC_IMAGES.length - 1) {
+      setPage(page + 1);
+    } else {
+      navigation.replace('Tabs', { screen: 'Gym' });
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} onTouchEnd={handlePress}>
+      <TouchableOpacity style={styles.container} activeOpacity={1} onPress={handlePress}>
+        <Image source={COMIC_IMAGES[page]} style={styles.image} resizeMode="contain" />
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+});


### PR DESCRIPTION
## Summary
- load comic images as assets
- display a comic sequence on app launch
- navigate to Gym tab after the comic
- allow TabNavigator to open to a specified tab

## Testing
- `npm install`
- `npm start -- --max-workers=1` *(fails: Unable to find expo in this project; after installing dependencies bundler starts)*

------
https://chatgpt.com/codex/tasks/task_e_685e196556d88328b251b04038855c56