### PR TITLE
Remove onboarding top bar

### DIFF
--- a/src/screens/GenderScreen.js
+++ b/src/screens/GenderScreen.js
@@ -14,17 +14,6 @@ export default function GenderScreen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.topBar}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
-        <View style={styles.progressBar}>
-          <View style={styles.progress} />
-        </View>
-        <TouchableOpacity>
-          <Text style={styles.lang}>🇺🇸 EN</Text>
-        </TouchableOpacity>
-      </View>
 
       <View>
         <Text style={styles.title}>Choose your Gender</Text>
@@ -61,31 +50,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 24,
     justifyContent: 'space-between',
-  },
-  topBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  progressBar: {
-    flex: 1,
-    height: 4,
-    backgroundColor: '#eee',
-    marginHorizontal: 12,
-    borderRadius: 2,
-  },
-  progress: {
-    width: '10%',
-    height: '100%',
-    backgroundColor: DARK,
-    borderRadius: 2,
-  },
-  lang: {
-    fontSize: 12,
-    backgroundColor: '#F2F2F2',
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-    borderRadius: 20,
   },
   title: {
     fontSize: 28,

--- a/src/screens/Onboarding1Screen.js
+++ b/src/screens/Onboarding1Screen.js
@@ -30,14 +30,6 @@ export default function Onboarding1Screen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.topBar}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
-        <View style={styles.progressBar}>
-          <View style={styles.progress} />
-        </View>
-      </View>
 
       <Text style={styles.header}>Build your gym buddy</Text>
 
@@ -145,23 +137,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 24,
     justifyContent: 'flex-start',
-  },
-  topBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  progressBar: {
-    flex: 1,
-    height: 4,
-    backgroundColor: '#eee',
-    marginHorizontal: 12,
-    borderRadius: 2,
-  },
-  progress: {
-    width: '20%',
-    height: '100%',
-    backgroundColor: DARK_BLUE,
-    borderRadius: 2,
   },
   header: {
     fontSize: 24,

--- a/src/screens/Onboarding2Screen.js
+++ b/src/screens/Onboarding2Screen.js
@@ -43,15 +43,6 @@ export default function Onboarding2Screen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* Top Bar */}
-      <View style={styles.topBar}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
-        <View style={styles.progressBar}>
-          <View style={styles.progress} />
-        </View>
-      </View>
 
       {/* Header */}
       <Text style={styles.title}>When were you born?</Text>
@@ -115,23 +106,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 24,
     justifyContent: 'flex-start',
-  },
-  topBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  progressBar: {
-    flex: 1,
-    height: 4,
-    backgroundColor: '#eee',
-    marginHorizontal: 12,
-    borderRadius: 2,
-  },
-  progress: {
-    width: '30%',
-    height: '100%',
-    backgroundColor: '#1C1B1F',
-    borderRadius: 2,
   },
   title: {
     fontSize: 28,

--- a/src/screens/Onboarding3Screen.js
+++ b/src/screens/Onboarding3Screen.js
@@ -32,14 +32,6 @@ export default function Onboarding3Screen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.topBar}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
-        <View style={styles.progressBar}>
-          <View style={styles.progress} />
-        </View>
-      </View>
       <View style={styles.options}>
         {CHARACTER_OPTIONS.map(opt => (
           <TouchableOpacity
@@ -76,23 +68,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 24,
     justifyContent: 'space-between',
-  },
-  topBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  progressBar: {
-    flex: 1,
-    height: 4,
-    backgroundColor: '#eee',
-    marginHorizontal: 12,
-    borderRadius: 2,
-  },
-  progress: {
-    width: '40%',
-    height: '100%',
-    backgroundColor: DARK,
-    borderRadius: 2,
   },
   title: {
     fontSize: 28,

--- a/src/screens/Onboarding4Screen.js
+++ b/src/screens/Onboarding4Screen.js
@@ -15,14 +15,6 @@ export default function Onboarding4Screen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.topBar}>
-        <TouchableOpacity onPress={() => navigation.goBack()}>
-          <Ionicons name="arrow-back" size={24} color="black" />
-        </TouchableOpacity>
-        <View style={styles.progressBar}>
-          <View style={styles.progress} />
-        </View>
-      </View>
 
       <View style={styles.options}>
         <TouchableOpacity
@@ -63,23 +55,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     padding: 24,
     justifyContent: 'space-between',
-  },
-  topBar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  progressBar: {
-    flex: 1,
-    height: 4,
-    backgroundColor: '#eee',
-    marginHorizontal: 12,
-    borderRadius: 2,
-  },
-  progress: {
-    width: '50%',
-    height: '100%',
-    backgroundColor: DARK,
-    borderRadius: 2,
   },
   options: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- drop top bar with back arrow and progress bar from onboarding screens
- remove unused top bar styles

## Testing
- `npm install`
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1a8b8b548328b40cd751aa77037a