### PR TITLE
Remove onboarding safe area gap

### DIFF
--- a/src/screens/GenderScreen.js
+++ b/src/screens/GenderScreen.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function GenderScreen({ navigation }) {
   const [selectedGender, setSelectedGender] = useState('Male');
@@ -13,7 +13,7 @@ export default function GenderScreen({ navigation }) {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
 
       <View>
         <Text style={styles.title}>Choose your Gender</Text>

--- a/src/screens/Onboarding1Screen.js
+++ b/src/screens/Onboarding1Screen.js
@@ -2,13 +2,12 @@ import React, { useState } from 'react';
 import {
   View,
   Text,
-  SafeAreaView,
   TouchableOpacity,
   StyleSheet,
   Switch,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import WheelPickerExpo from 'react-native-wheel-picker-expo';
-import { Ionicons } from '@expo/vector-icons';
 
 export default function Onboarding1Screen({ navigation }) {
   const [useMetric, setUseMetric] = useState(false);
@@ -29,7 +28,7 @@ export default function Onboarding1Screen({ navigation }) {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
 
       <Text style={styles.header}>Build your gym buddy</Text>
 

--- a/src/screens/Onboarding2Screen.js
+++ b/src/screens/Onboarding2Screen.js
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 import {
   View,
   Text,
-  SafeAreaView,
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import WheelPickerExpo from 'react-native-wheel-picker-expo';
-import { Ionicons } from '@expo/vector-icons';
 
 export default function Onboarding2Screen({ navigation }) {
   const [monthIndex, setMonthIndex] = useState(0);
@@ -42,7 +41,7 @@ export default function Onboarding2Screen({ navigation }) {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
 
       {/* Header */}
       <Text style={styles.title}>When were you born?</Text>

--- a/src/screens/Onboarding3Screen.js
+++ b/src/screens/Onboarding3Screen.js
@@ -2,14 +2,13 @@ import React, { useState } from 'react';
 import {
   View,
   Text,
-  SafeAreaView,
   TouchableOpacity,
   Image,
   StyleSheet,
   TextInput,
   Alert,
 } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_OPTIONS } from '../data/characters';
 import { Filter } from 'bad-words';
@@ -31,7 +30,7 @@ export default function Onboarding3Screen({ navigation }) {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
       <View style={styles.options}>
         {CHARACTER_OPTIONS.map(opt => (
           <TouchableOpacity

--- a/src/screens/Onboarding4Screen.js
+++ b/src/screens/Onboarding4Screen.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, SafeAreaView, TouchableOpacity, Image, StyleSheet } from 'react-native';
-import { Ionicons } from '@expo/vector-icons';
+import { View, Text, TouchableOpacity, Image, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useBackground } from '../context/BackgroundContext';
 
 export default function Onboarding4Screen({ navigation }) {
@@ -14,7 +14,7 @@ export default function Onboarding4Screen({ navigation }) {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['left', 'right', 'bottom']}>
 
       <View style={styles.options}>
         <TouchableOpacity


### PR DESCRIPTION
## Summary
- import SafeAreaView from safe-area-context in onboarding flow
- drop unused Ionicons imports
- ignore top safe area on initial onboarding screens

## Testing
- `npm install`
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1d21b4548328b7b717f00e8a827a