### PR TITLE
Set black status bar

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ import { HistoryProvider } from './src/context/HistoryContext';
 import { StatsProvider } from './src/context/StatsContext';
 import { BackgroundProvider } from './src/context/BackgroundContext';
 import { Asset } from 'expo-asset';
+import { StatusBar } from 'expo-status-bar';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
 import { CHARACTER_IMAGES } from './src/data/characters';
 import { COMIC_IMAGES } from './src/data/comicPages';
@@ -45,6 +46,7 @@ export default function App() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
+      <StatusBar style="light" backgroundColor="black" />
       <SafeAreaProvider>
         <HistoryProvider>
           <StatsProvider>


### PR DESCRIPTION
## Summary
- add StatusBar with black background

## Testing
- `npm install`
- `npm start` *(fails: waiting for Metro Bundler)*

------
https://chatgpt.com/codex/tasks/task_e_686075319be88328b64aaa61341b39a9