### PR TITLE
Fix expo-status-bar dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "expo": "~53.0.11",
         "expo-av": "^15.1.6",
         "expo-image-picker": "^16.1.4",
+        "expo-status-bar": "^2.2.3",
         "firebase": "^11.9.1",
         "matter-js": "^0.20.0",
         "react": "19.0.0",
@@ -5404,6 +5405,20 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-status-bar": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.2.3.tgz",
+      "integrity": "sha512-+c8R3AESBoduunxTJ8353SqKAKpxL6DvcD8VKBuh81zzJyUUbfB4CVjr1GufSJEKsMzNPXZU+HJwXx7Xh7lx8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-edge-to-edge": "1.6.0",
+        "react-native-is-edge-to-edge": "^1.1.6"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo": "~53.0.11",
     "expo-av": "^15.1.6",
     "expo-image-picker": "^16.1.4",
+    "expo-status-bar": "^2.2.3",
     "firebase": "^11.9.1",
     "matter-js": "^0.20.0",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- install `expo-status-bar` dependency so the App can import it

## Testing
- `npm start -- --non-interactive --max-workers=1` *(fails: Starting Metro bundler then killed)*

------
https://chatgpt.com/codex/tasks/task_e_68607742525c83288b481ecf49a186a9