### PR TITLE
Limit history calendar swiping

### DIFF
--- a/src/context/SwipeContext.js
+++ b/src/context/SwipeContext.js
@@ -1,0 +1,8 @@
+import React, { createContext, useContext } from 'react';
+
+const SwipeContext = createContext({ setSwipeEnabled: () => {} });
+
+export const useSwipe = () => useContext(SwipeContext);
+export const SwipeProvider = SwipeContext.Provider;
+
+export default SwipeContext;

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -2,7 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { StyleSheet, View, useWindowDimensions, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { TabView, SceneMap } from 'react-native-tab-view';
+import { TabView } from 'react-native-tab-view';
+
+import { SwipeProvider } from '../context/SwipeContext';
 
 import GymScreen from '../screens/GymScreen';
 import HistoryScreen from '../screens/HistoryScreen';
@@ -31,11 +33,20 @@ export default function TabNavigator({ route }) {
     }
   }, [route?.params?.screen]);
 
-  const renderScene = SceneMap({
-    Profile: ProfileScreen,
-    Gym: GymScreen,
-    History: HistoryScreen,
-  });
+  const [swipeEnabled, setSwipeEnabled] = useState(true);
+
+  const renderScene = ({ route }) => {
+    switch (route.key) {
+      case 'Profile':
+        return <ProfileScreen />;
+      case 'Gym':
+        return <GymScreen />;
+      case 'History':
+        return <HistoryScreen setSwipeEnabled={setSwipeEnabled} />;
+      default:
+        return null;
+    }
+  };
 
   const renderTabBar = () => (
     <View style={styles.tabBar}>
@@ -60,17 +71,19 @@ export default function TabNavigator({ route }) {
   );
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <TabView
-        navigationState={{ index, routes }}
-        renderScene={renderScene}
-        onIndexChange={setIndex}
-        initialLayout={{ width: layout.width }}
-        renderTabBar={() => null}
-        swipeEnabled
-      />
-      {renderTabBar()}
-    </SafeAreaView>
+    <SwipeProvider value={{ setSwipeEnabled }}>
+      <SafeAreaView style={{ flex: 1 }}>
+        <TabView
+          navigationState={{ index, routes }}
+          renderScene={renderScene}
+          onIndexChange={setIndex}
+          initialLayout={{ width: layout.width }}
+          renderTabBar={() => null}
+          swipeEnabled={swipeEnabled}
+        />
+        {renderTabBar()}
+      </SafeAreaView>
+    </SwipeProvider>
   );
 }
 

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -31,7 +31,7 @@ function generateMonth(year, month) {
 }
 
 
-export default function HistoryScreen() {
+export default function HistoryScreen({ setSwipeEnabled }) {
   const today = new Date();
 
   const { characterId } = useCharacter();
@@ -86,6 +86,10 @@ export default function HistoryScreen() {
     }
   };
 
+  useEffect(() => {
+    return () => setSwipeEnabled(true);
+  }, [setSwipeEnabled]);
+
 
 
   return (
@@ -95,7 +99,11 @@ export default function HistoryScreen() {
         pagingEnabled
         showsHorizontalScrollIndicator={false}
         ref={scrollRef}
-        onMomentumScrollEnd={handleMomentumScrollEnd}
+        onScrollBeginDrag={() => setSwipeEnabled(false)}
+        onMomentumScrollEnd={e => {
+          handleMomentumScrollEnd(e);
+          setSwipeEnabled(true);
+        }}
         contentContainerStyle={styles.monthScroll}
       >
         {months.map((m, idx) => (


### PR DESCRIPTION
## Summary
- add SwipeContext
- control TabView swiping from TabNavigator
- disable TabView swipe when interacting with the calendar

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_686075e3f7988328917cdfae6fe1ec64