### PR TITLE
Preload background images

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,6 +14,7 @@ import { StatusBar } from 'expo-status-bar';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
 import { CHARACTER_IMAGES } from './src/data/characters';
 import { COMIC_IMAGES } from './src/data/comicPages';
+import { BACKGROUND_IMAGES } from './src/data/backgroundImages';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -30,6 +31,7 @@ export default function App() {
         ...Object.values(EQUIPMENT_IMAGES),
         ...Object.values(CHARACTER_IMAGES),
         ...COMIC_IMAGES,
+        ...Object.values(BACKGROUND_IMAGES),
       ]);
       setAssetsLoaded(true);
     }

--- a/src/data/backgroundImages.js
+++ b/src/data/backgroundImages.js
@@ -1,0 +1,5 @@
+export const BACKGROUND_IMAGES = {
+  oldschool: require('../../assets/backgrounds/APP_BG_oldschool.png'),
+  newschool: require('../../assets/backgrounds/APP_BG_newschool.png'),
+  explore: require('../explore_bg.png'),
+};


### PR DESCRIPTION
## Summary
- add BACKGROUND_IMAGES data file
- cache background images in App.js

## Testing
- `npx expo start --offline` *(fails: expo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68607f180164832883666b3dafb2cdfc