### PR TITLE
Adjust history entry limit and calendar layout

### DIFF
--- a/src/context/HistoryContext.js
+++ b/src/context/HistoryContext.js
@@ -35,7 +35,7 @@ export const HistoryProvider = ({ children }) => {
     setHistory(h => {
       const dayEntries = h[dateStr] ? [...h[dateStr]] : [];
       dayEntries.push(workout);
-      if (dayEntries.length > 3) {
+      if (dayEntries.length > 2) {
         dayEntries.shift();
       }
       return { ...h, [dateStr]: dayEntries };

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -15,7 +15,8 @@ const MONTH_NAMES = [
 ];
 const WEEK_DAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
+const CALENDAR_OFFSET = SCREEN_HEIGHT * 0.05;
 const CELL_SIZE = Math.floor((SCREEN_WIDTH - 32) / 7);
 
 function generateMonth(year, month) {
@@ -95,6 +96,7 @@ export default function HistoryScreen({ setSwipeEnabled }) {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView
+        style={styles.calendarWrapper}
         horizontal
         pagingEnabled
         showsHorizontalScrollIndicator={false}
@@ -232,6 +234,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
+  },
+  calendarWrapper: {
+    marginTop: -CALENDAR_OFFSET,
   },
   monthScroll: {
     alignItems: 'flex-start',


### PR DESCRIPTION
## Summary
- limit stored workout entries per day to 2
- shift the calendar view slightly upward

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607fbc618c832888e6ee670a47e3ea