### PR TITLE
Fix status bar and safe area handling

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,7 +10,7 @@ import { HistoryProvider } from './src/context/HistoryContext';
 import { StatsProvider } from './src/context/StatsContext';
 import { BackgroundProvider } from './src/context/BackgroundContext';
 import { Asset } from 'expo-asset';
-import { StatusBar } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
 import { CHARACTER_IMAGES } from './src/data/characters';
 import { COMIC_IMAGES } from './src/data/comicPages';
@@ -48,9 +48,9 @@ export default function App() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaView edges={['top']} style={{ flex: 0, backgroundColor: 'black' }} />
-      <StatusBar barStyle="light-content" backgroundColor="black" translucent />
       <SafeAreaProvider>
+        <SafeAreaView edges={['top']} style={{ flex: 0, backgroundColor: 'black' }} />
+        <StatusBar style="light" backgroundColor="black" />
         <HistoryProvider>
           <StatsProvider>
             <CharacterProvider>

--- a/src/screens/ActivityScreen.js
+++ b/src/screens/ActivityScreen.js
@@ -11,7 +11,7 @@ export default function ActivityScreen({ navigation }) {
   ];
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.goBack()}>
           <Ionicons name="arrow-back" size={24} color="#222" />

--- a/src/screens/ComicScreen.js
+++ b/src/screens/ComicScreen.js
@@ -15,7 +15,7 @@ export default function ComicScreen({ navigation }) {
   };
 
   return (
-    <SafeAreaView style={styles.container} onTouchEnd={handlePress}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container} onTouchEnd={handlePress}>
       <TouchableOpacity style={styles.container} activeOpacity={1} onPress={handlePress}>
         <Image source={COMIC_IMAGES[page]} style={styles.image} resizeMode="contain" />
       </TouchableOpacity>

--- a/src/screens/FriendsScreen.js
+++ b/src/screens/FriendsScreen.js
@@ -7,7 +7,7 @@ export default function FriendsScreen({ navigation }) {
   const friends = ['MegMx', 'malak', 'DorothyDark'];
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.goBack()}>
           <Ionicons name="arrow-back" size={24} color="#222" />

--- a/src/screens/GymGameScreen.js
+++ b/src/screens/GymGameScreen.js
@@ -74,7 +74,7 @@ export default function GymGameScreen() {
   );
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <GameEngine
         style={styles.engine}
         systems={[Physics, TouchHandler]}

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -497,7 +497,7 @@ const toggleWorkout = useCallback(() => {
       resizeMode="cover"
     >
       <View style={{flex: 1}} pointerEvents="box-none">
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <ScrollView contentContainerStyle={styles.contentContainer}>
         {workouts[selectedWorkoutIdx] && (
           <View key={selectedWorkoutIdx} style={styles.workoutCard}>

--- a/src/screens/HistoryScreen.js
+++ b/src/screens/HistoryScreen.js
@@ -94,7 +94,7 @@ export default function HistoryScreen({ setSwipeEnabled }) {
 
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <ScrollView
         style={styles.calendarWrapper}
         horizontal

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import SignInModal from '../components/SignInModal';
 
 const OnboardingScreen = ({ navigation }) => {
   const [modalVisible, setModalVisible] = useState(false);
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <View style={styles.topRightLang}>
         <Text style={styles.language}>🇺🇸 EN</Text>
       </View>

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -72,7 +72,7 @@ export default function ProfileScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       {/* Top Bar */}
       <View style={styles.topBar}>
         <TouchableOpacity onPress={() => navigation.navigate('Settings')}>

--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -5,7 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 
 export default function SettingsScreen({ navigation }) {
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView edges={['left','right','bottom']} style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.goBack()}>
           <Ionicons name="arrow-back" size={24} color="#222" />


### PR DESCRIPTION
## Summary
- use expo StatusBar instead of React Native one
- move SafeAreaProvider to wrap the app
- exclude top edge on screens so the status bar background stays black

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608f9f3ec083288a57a03f26b7ae33