### PR TITLE
Fix status bar gap

### DIFF
--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -72,7 +72,7 @@ export default function TabNavigator({ route }) {
 
   return (
     <SwipeProvider value={{ setSwipeEnabled }}>
-      <SafeAreaView style={{ flex: 1 }}>
+      <SafeAreaView edges={['left', 'right', 'bottom']} style={{ flex: 1 }}>
         <TabView
           navigationState={{ index, routes }}
           renderScene={renderScene}


### PR DESCRIPTION
## Summary
- remove top safe area padding from TabNavigator to prevent grey bar under the status bar

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68609197bc1883289c6e7c34562f5eec