### PR TITLE
Implement first-run comic navigation

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -1,18 +1,31 @@
-import React from 'react';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import TabNavigator from './TabNavigator';
-import SettingsScreen from '../screens/SettingsScreen';
-import ActivityScreen from '../screens/ActivityScreen';
-import FriendsScreen from '../screens/FriendsScreen';
-import ComicScreen from '../screens/ComicScreen';
+import React, { useState, useEffect } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import TabNavigator from "./TabNavigator";
+import SettingsScreen from "../screens/SettingsScreen";
+import ActivityScreen from "../screens/ActivityScreen";
+import FriendsScreen from "../screens/FriendsScreen";
+import ComicScreen from "../screens/ComicScreen";
 
 const Stack = createNativeStackNavigator();
 
 export default function RootNavigator() {
+  const [initialRoute, setInitialRoute] = useState(null);
+
+  useEffect(() => {
+    AsyncStorage.getItem("hasSeenComic").then((value) => {
+      setInitialRoute(value ? "Tabs" : "Comic");
+    });
+  }, []);
+
+  if (!initialRoute) {
+    return null;
+  }
+
   return (
     <Stack.Navigator
       screenOptions={{ headerShown: false }}
-      initialRouteName="Comic"
+      initialRouteName={initialRoute}
     >
       <Stack.Screen name="Comic" component={ComicScreen} />
       <Stack.Screen name="Tabs" component={TabNavigator} />

--- a/src/screens/ComicScreen.js
+++ b/src/screens/ComicScreen.js
@@ -1,23 +1,37 @@
-import React, { useState } from 'react';
-import { TouchableOpacity, Image, StyleSheet, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { COMIC_IMAGES } from '../data/comicPages';
+import React, { useState } from "react";
+import { TouchableOpacity, ImageBackground, StyleSheet } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { COMIC_IMAGES } from "../data/comicPages";
 
 export default function ComicScreen({ navigation }) {
   const [page, setPage] = useState(0);
 
-  const handlePress = () => {
+  const handlePress = async () => {
     if (page < COMIC_IMAGES.length - 1) {
       setPage(page + 1);
     } else {
-      navigation.replace('Tabs', { screen: 'Gym' });
+      await AsyncStorage.setItem("hasSeenComic", "true");
+      navigation.replace("Tabs", { screen: "Gym" });
     }
   };
 
   return (
-    <SafeAreaView edges={['left','right','bottom']} style={styles.container} onTouchEnd={handlePress}>
-      <TouchableOpacity style={styles.container} activeOpacity={1} onPress={handlePress}>
-        <Image source={COMIC_IMAGES[page]} style={styles.image} resizeMode="contain" />
+    <SafeAreaView
+      edges={["left", "right", "bottom"]}
+      style={styles.container}
+      onTouchEnd={handlePress}
+    >
+      <TouchableOpacity
+        style={styles.container}
+        activeOpacity={1}
+        onPress={handlePress}
+      >
+        <ImageBackground
+          source={COMIC_IMAGES[page]}
+          style={styles.image}
+          resizeMode="cover"
+        />
       </TouchableOpacity>
     </SafeAreaView>
   );
@@ -26,12 +40,12 @@ export default function ComicScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#000',
-    justifyContent: 'center',
-    alignItems: 'center',
+    backgroundColor: "#000",
+    justifyContent: "center",
+    alignItems: "center",
   },
   image: {
-    width: '100%',
-    height: '100%',
+    width: "100%",
+    height: "100%",
   },
 });


### PR DESCRIPTION
## Summary
- trigger comic only on first launch
- record first-run completion in `AsyncStorage`
- show full-screen comic images with `ImageBackground`

## Testing
- `npm install`
- `npm start -- --max-workers=1` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68609246a25c8328bd6b0f015d8040c4