### PR TITLE
Fix double bottom bar

### DIFF
--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -81,8 +81,8 @@ export default function TabNavigator({ route }) {
           renderTabBar={() => null}
           swipeEnabled={swipeEnabled}
         />
+        {renderTabBar()}
       </SafeAreaView>
-      {renderTabBar()}
     </SwipeProvider>
   );
 }
@@ -96,6 +96,7 @@ const styles = StyleSheet.create({
   tabItem: {
     flex: 1,
     alignItems: 'center',
-    padding: 10,
+    justifyContent: 'center',
+    paddingVertical: 10,
   },
 });


### PR DESCRIPTION
## Summary
- place TabNavigator's tab bar inside SafeAreaView
- vertically center icons in the bottom bar

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609b731ba88328bec283f581ac12f1