### PR TITLE
Improve weight formatting

### DIFF
--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -1,4 +1,7 @@
 export function formatWeight(weight) {
+  if (weight >= 1000000) {
+    return `${(weight / 1000000).toFixed(2)} M`;
+  }
   if (weight >= 100000) {
     return `${Math.round(weight / 1000)}k`;
   }


### PR DESCRIPTION
## Summary
- update `formatWeight` to display values above one million in millions with two decimals

## Testing
- `npm start` *(fails: Unable to find expo in this project - have you run yarn / npm install yet?)*


------
https://chatgpt.com/codex/tasks/task_e_68609d1274c883288d73d0982e0ad373