### PR TITLE
Add install date-based month selection

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,7 @@ import { CharacterProvider } from './src/context/CharacterContext';
 import { HistoryProvider } from './src/context/HistoryContext';
 import { StatsProvider } from './src/context/StatsContext';
 import { BackgroundProvider } from './src/context/BackgroundContext';
+import { InstallDateProvider } from './src/context/InstallDateContext';
 import { Asset } from 'expo-asset';
 import { StatusBar } from 'expo-status-bar';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
@@ -51,17 +52,19 @@ export default function App() {
       <SafeAreaProvider>
         <SafeAreaView edges={['top']} style={{ flex: 0, backgroundColor: 'black' }} />
         <StatusBar style="light" backgroundColor="black" />
-        <HistoryProvider>
-          <StatsProvider>
-            <CharacterProvider>
-              <BackgroundProvider>
-                <NavigationContainer>
-                  <RootNavigator />
-                </NavigationContainer>
-              </BackgroundProvider>
-            </CharacterProvider>
-          </StatsProvider>
-        </HistoryProvider>
+        <InstallDateProvider>
+          <HistoryProvider>
+            <StatsProvider>
+              <CharacterProvider>
+                <BackgroundProvider>
+                  <NavigationContainer>
+                    <RootNavigator />
+                  </NavigationContainer>
+                </BackgroundProvider>
+              </CharacterProvider>
+            </StatsProvider>
+          </HistoryProvider>
+        </InstallDateProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/src/context/InstallDateContext.js
+++ b/src/context/InstallDateContext.js
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const InstallDateContext = createContext(new Date());
+
+export const InstallDateProvider = ({ children }) => {
+  const [installDate, setInstallDate] = useState(new Date());
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem('installDate');
+        if (stored) {
+          const parsed = parseInt(stored, 10);
+          if (!Number.isNaN(parsed)) {
+            setInstallDate(new Date(parsed));
+            return;
+          }
+        }
+        const now = Date.now();
+        setInstallDate(new Date(now));
+        await AsyncStorage.setItem('installDate', String(now));
+      } catch {}
+    })();
+  }, []);
+
+  return (
+    <InstallDateContext.Provider value={installDate}>
+      {children}
+    </InstallDateContext.Provider>
+  );
+};
+
+export const useInstallDate = () => useContext(InstallDateContext);


### PR DESCRIPTION
## Summary
- add `InstallDateContext` to store and provide app install date
- wrap app providers with `InstallDateProvider`
- generate calendar months starting from install date in `HistoryScreen`

## Testing
- `npm start` *(fails: expo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68609ec599008328b2bca48335aa1748