### PR TITLE
Add test mode to replay onboarding comic

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { TEST_MODE } from "../utils/config";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import TabNavigator from "./TabNavigator";
 import SettingsScreen from "../screens/SettingsScreen";
@@ -13,9 +14,13 @@ export default function RootNavigator() {
   const [initialRoute, setInitialRoute] = useState(null);
 
   useEffect(() => {
-    AsyncStorage.getItem("hasSeenComic").then((value) => {
-      setInitialRoute(value ? "Tabs" : "Comic");
-    });
+    if (TEST_MODE) {
+      setInitialRoute("Comic");
+    } else {
+      AsyncStorage.getItem("hasSeenComic").then((value) => {
+        setInitialRoute(value ? "Tabs" : "Comic");
+      });
+    }
   }, []);
 
   if (!initialRoute) {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,4 @@
+// Toggle this flag to re-run the initial comic sequence
+// even if it has been completed before.
+export const TEST_MODE = false;
+


### PR DESCRIPTION
## Summary
- add `TEST_MODE` flag in `src/utils/config.js`
- use the flag to force the ComicScreen on startup

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a52f0c188328a410a7458773a77d