### PR TITLE
Fix comic screen image layout

### DIFF
--- a/src/screens/ComicScreen.js
+++ b/src/screens/ComicScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { TouchableOpacity, ImageBackground, StyleSheet } from "react-native";
+import { TouchableOpacity, Image, StyleSheet } from "react-native";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { COMIC_IMAGES } from "../data/comicPages";
@@ -27,10 +27,10 @@ export default function ComicScreen({ navigation }) {
         activeOpacity={1}
         onPress={handlePress}
       >
-        <ImageBackground
+        <Image
           source={COMIC_IMAGES[page]}
           style={styles.image}
-          resizeMode="cover"
+          resizeMode="contain"
         />
       </TouchableOpacity>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- replace ImageBackground with Image
- use `contain` resize mode to show full comic pages

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860aa841940832895028e98820db0df