### PR TITLE
Add character naming modal

### DIFF
--- a/src/components/NamePetModal.js
+++ b/src/components/NamePetModal.js
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, Modal, StyleSheet, TouchableWithoutFeedback } from 'react-native';
+import AvatarWithLevelBadge from './AvatarWithLevelBadge';
+import ExpBar from './ExpBar';
+import { useCharacter } from '../context/CharacterContext';
+import { CHARACTER_IMAGES } from '../data/characters';
+
+export default function NamePetModal({ visible, onClose }) {
+  const { characterId, setPetName } = useCharacter();
+  const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GorillaM;
+  const [name, setName] = useState('');
+  const [showExp, setShowExp] = useState(false);
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setPetName(trimmed);
+    setShowExp(true);
+  };
+
+  return (
+    <Modal transparent visible={visible} animationType="fade">
+      <TouchableWithoutFeedback onPress={showExp ? onClose : undefined}>
+        <View style={styles.overlay}>
+          <View style={styles.card}>
+            <View style={styles.row}>
+              <AvatarWithLevelBadge source={sprite} size={80} level={1} />
+              <View style={styles.right}>
+                {!showExp && (
+                  <>
+                    <Text style={styles.label}>Name your buddy</Text>
+                    <TextInput
+                      style={styles.input}
+                      placeholder="Enter name"
+                      placeholderTextColor="#888"
+                      value={name}
+                      onChangeText={setName}
+                    />
+                    <TouchableOpacity style={styles.button} onPress={handleSave}>
+                      <Text style={styles.buttonText}>Save</Text>
+                    </TouchableOpacity>
+                  </>
+                )}
+                {showExp && (
+                  <>
+                    <Text style={styles.savedText}>Great! Meet {name.trim()}.</Text>
+                    <View style={styles.expBar}>
+                      <ExpBar exp={0} width={100} height={8} />
+                    </View>
+                    <TouchableOpacity style={styles.button} onPress={onClose}>
+                      <Text style={styles.buttonText}>Continue</Text>
+                    </TouchableOpacity>
+                  </>
+                )}
+              </View>
+            </View>
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 20,
+    width: '80%',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  right: {
+    flex: 1,
+    marginLeft: 16,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#222',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 8,
+    marginBottom: 12,
+    color: '#222',
+  },
+  button: {
+    backgroundColor: '#4CAF50',
+    paddingVertical: 8,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  savedText: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 12,
+    color: '#222',
+  },
+  expBar: {
+    marginBottom: 12,
+    alignItems: 'flex-end',
+  },
+});

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -30,11 +30,13 @@ import TouchHandler from '../systems/TouchHandler';
 import ExerciseSelector from '../components/ExerciseSelector';
 import EquipmentGrid from '../components/EquipmentGrid';
 import LevelUpModal from '../components/LevelUpModal';
+import NamePetModal from '../components/NamePetModal';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_IMAGES } from '../data/characters';
 import { useBackground } from '../context/BackgroundContext';
 import oldBG from '../../assets/backgrounds/APP_BG_oldschool.png';
 import newBG from '../../assets/backgrounds/APP_BG_newschool.png';
+import { TEST_MODE } from '../utils/config';
 
 const SPRITE_SIZE = 120;
 
@@ -134,6 +136,7 @@ export default function GymScreen() {
   const [deleteMode, setDeleteMode] = useState(false);
   const [setCounts, setSetCounts] = useState([]);
   const { addEntry } = useHistory();
+  const [showNameModal, setShowNameModal] = useState(false);
 
   const engine = useRef(Matter.Engine.create({ enableSleeping: false }));
   const world = engine.current.world;
@@ -166,6 +169,12 @@ export default function GymScreen() {
   const [showStatsModal, setShowStatsModal] = useState(false);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
   const [startLevel, setStartLevel] = useState(level);
+
+  useEffect(() => {
+    if ((TEST_MODE || !petName) && !showNameModal) {
+      setShowNameModal(true);
+    }
+  }, [petName, showNameModal]);
 
   const showStats = useCallback(() => {
     setShowStatsModal(true);
@@ -558,7 +567,11 @@ const toggleWorkout = useCallback(() => {
           style={styles.engine}
           onEvent={onEvent}
         >
-          <Character body={characterBody} sprite={sprite} petName={petName} />
+          <Character
+            body={characterBody}
+            sprite={sprite}
+            petName={!workoutActive ? petName : ''}
+          />
         </GameEngine>
       </View>
       {workoutActive && (
@@ -770,6 +783,11 @@ const toggleWorkout = useCallback(() => {
           </View>
         </View>
       </Modal>
+
+      <NamePetModal
+        visible={showNameModal}
+        onClose={() => setShowNameModal(false)}
+      />
 
       <LevelUpModal
         visible={showLevelUpModal}


### PR DESCRIPTION
## Summary
- create `NamePetModal` for naming character
- open naming modal in gym when pet has no name or in test mode
- hide name overlay during lifts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860ad521fc083288713ca014f32ff09