### PR TITLE
Change first level EXP requirement

### DIFF
--- a/src/utils/levelUtils.js
+++ b/src/utils/levelUtils.js
@@ -1,4 +1,7 @@
 export function getNextLevelExp(level) {
+  if (level === 1) {
+    return 1;
+  }
   return 10 + 3 * (level - 1);
 }
 


### PR DESCRIPTION
## Summary
- tweak level progression so only 1 EXP is required from level 1 to 2

## Testing
- `npm start -- --max-workers=1` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c72e24408328880a80d056a1cbeb