### PR TITLE
Add narration boxes to comic

### DIFF
--- a/src/components/NarrationBox.js
+++ b/src/components/NarrationBox.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function NarrationBox({ text, style }) {
+  return (
+    <View style={[styles.container, style]}>
+      <Text style={styles.text}>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#FFEB3B',
+    borderColor: 'black',
+    borderWidth: 3,
+    padding: 10,
+  },
+  text: {
+    fontFamily: 'Comic Neue',
+    fontSize: 14,
+  },
+});

--- a/src/data/comicNarrations.js
+++ b/src/data/comicNarrations.js
@@ -1,0 +1,22 @@
+export const COMIC_NARRATIONS = [
+  {
+    text: 'Later that night…',
+    style: { top: 20, left: 20 },
+  },
+  {
+    text: 'Suddenly, a shadow appears',
+    style: { top: 20, right: 20 },
+  },
+  {
+    text: 'The gorilla approaches!',
+    style: { bottom: 20, left: 20 },
+  },
+  {
+    text: 'Our hero is shocked',
+    style: { top: 20, left: 20 },
+  },
+  {
+    text: 'What will happen next?',
+    style: { bottom: 20, right: 20 },
+  },
+];

--- a/src/screens/ComicScreen.js
+++ b/src/screens/ComicScreen.js
@@ -3,6 +3,8 @@ import { TouchableWithoutFeedback, ImageBackground, StyleSheet } from "react-nat
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { COMIC_IMAGES } from "../data/comicPages";
+import { COMIC_NARRATIONS } from "../data/comicNarrations";
+import NarrationBox from "../components/NarrationBox";
 
 export default function ComicScreen({ navigation }) {
   const [page, setPage] = useState(0);
@@ -23,7 +25,14 @@ export default function ComicScreen({ navigation }) {
           source={COMIC_IMAGES[page]}
           style={styles.image}
           resizeMode="cover"
-        />
+        >
+          {COMIC_NARRATIONS[page] && (
+            <NarrationBox
+              text={COMIC_NARRATIONS[page].text}
+              style={[styles.narration, COMIC_NARRATIONS[page].style]}
+            />
+          )}
+        </ImageBackground>
       </TouchableWithoutFeedback>
     </SafeAreaView>
   );
@@ -37,5 +46,8 @@ const styles = StyleSheet.create({
   image: {
     width: "100%",
     height: "100%",
+  },
+  narration: {
+    position: "absolute",
   },
 });


### PR DESCRIPTION
## Summary
- overlay narration boxes on each comic image
- add `NarrationBox` component for comic style text boxes
- define per-slide narration text and position

## Testing
- `npx expo --version` *(fails: package not installed)*
- `npm start -- --help` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ca18e61c8328a8bcf7a980581eb3