### PR TITLE
Add storage reset for test mode

### DIFF
--- a/App.js
+++ b/App.js
@@ -9,6 +9,8 @@ import { CharacterProvider } from './src/context/CharacterContext';
 import { HistoryProvider } from './src/context/HistoryContext';
 import { StatsProvider } from './src/context/StatsContext';
 import { BackgroundProvider } from './src/context/BackgroundContext';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { TEST_MODE } from './src/utils/config';
 import { Asset } from 'expo-asset';
 import { StatusBar } from 'expo-status-bar';
 import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
@@ -24,6 +26,13 @@ LogBox.ignoreLogs([
 
 export default function App() {
   const [assetsLoaded, setAssetsLoaded] = useState(false);
+  const [resetDone, setResetDone] = useState(!TEST_MODE);
+
+  useEffect(() => {
+    if (TEST_MODE) {
+      AsyncStorage.clear().finally(() => setResetDone(true));
+    }
+  }, []);
 
   useEffect(() => {
     async function loadAssets() {
@@ -35,10 +44,12 @@ export default function App() {
       ]);
       setAssetsLoaded(true);
     }
-    loadAssets();
-  }, []);
+    if (resetDone) {
+      loadAssets();
+    }
+  }, [resetDone]);
 
-  if (!assetsLoaded) {
+  if (!resetDone || !assetsLoaded) {
     return (
       <GestureHandlerRootView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
         <ActivityIndicator size="large" />


### PR DESCRIPTION
## Summary
- clear AsyncStorage when TEST_MODE is enabled so the app always starts fresh
- wait for reset and assets before rendering the app

## Testing
- `npm install`
- `npm start` *(fails: waiting for bundler output)*

------
https://chatgpt.com/codex/tasks/task_e_6861e95fc48c8328bca2a4dbf85d0b8e