### PR TITLE
Implement Firebase auth sign in prompt

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,6 +18,7 @@ import { EQUIPMENT_IMAGES } from './src/data/exerciseEquipmentMap';
 import { CHARACTER_IMAGES } from './src/data/characters';
 import { COMIC_IMAGES } from './src/data/comicPages';
 import { BACKGROUND_IMAGES } from './src/data/backgroundImages';
+import { AuthProvider } from './src/context/AuthContext';
 
 // Ignore specific warnings
 LogBox.ignoreLogs([
@@ -63,19 +64,21 @@ export default function App() {
       <SafeAreaProvider>
         <SafeAreaView edges={['top']} style={{ flex: 0, backgroundColor: 'black' }} />
         <StatusBar style="light" backgroundColor="black" />
-        <HistoryProvider>
-          <StatsProvider>
-            <CharacterProvider>
-              <NotificationProvider>
-                <BackgroundProvider>
-                  <NavigationContainer>
-                    <RootNavigator />
-                  </NavigationContainer>
-                </BackgroundProvider>
-              </NotificationProvider>
-            </CharacterProvider>
-          </StatsProvider>
-        </HistoryProvider>
+        <AuthProvider>
+          <HistoryProvider>
+            <StatsProvider>
+              <CharacterProvider>
+                <NotificationProvider>
+                  <BackgroundProvider>
+                    <NavigationContainer>
+                      <RootNavigator />
+                    </NavigationContainer>
+                  </BackgroundProvider>
+                </NotificationProvider>
+              </CharacterProvider>
+            </StatsProvider>
+          </HistoryProvider>
+        </AuthProvider>
       </SafeAreaProvider>
     </GestureHandlerRootView>
   );

--- a/firebase.js
+++ b/firebase.js
@@ -1,26 +1,22 @@
-// Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
-import { initializeAuth, getReactNativePersistence } from "firebase/auth";
+// Firebase initialization
+import { initializeApp } from 'firebase/app';
+import { getAnalytics } from 'firebase/analytics';
+import { initializeAuth, getReactNativePersistence } from 'firebase/auth';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
-
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  apiKey: "AIzaSyCtkx_K1nbDCKD0itmrlPBrLm0tr1aAg1s",
-  authDomain: "liftable-c57ad.firebaseapp.com",
-  projectId: "liftable-c57ad",
-  storageBucket: "liftable-c57ad.firebasestorage.app",
-  messagingSenderId: "290700309837",
-  appId: "1:290700309837:web:b19c3d3b3a320f97f9b304",
-  measurementId: "G-FMV6MS1S70"
+  apiKey: 'AIzaSyCtkx_K1nbDCKD0itmrlPBrLm0tr1aAg1s',
+  authDomain: 'liftable-c57ad.firebaseapp.com',
+  projectId: 'liftable-c57ad',
+  storageBucket: 'liftable-c57ad.firebasestorage.app',
+  messagingSenderId: '290700309837',
+  appId: '1:290700309837:web:b19c3d3b3a320f97f9b304',
+  measurementId: 'G-FMV6MS1S70',
 };
 
-// Initialize Firebase
 const app = initializeApp(firebaseConfig);
-export const auth = initializeAuth(app, {persistence: getReactNativePersistence(AsyncStorage)});
+export const auth = initializeAuth(app, {
+  persistence: getReactNativePersistence(AsyncStorage),
+});
 
-const analytics = getAnalytics(app);
+export const analytics = getAnalytics(app);

--- a/src/components/SignInModal.js
+++ b/src/components/SignInModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Modal,
   View,
@@ -7,10 +7,32 @@ import {
   StyleSheet,
   Image,
   Linking,
+  TextInput,
+  Alert,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useAuth } from '../context/AuthContext';
 
 const SignInModal = ({ visible, onClose }) => {
+  const { signIn, signUp } = useAuth();
+  const [showEmail, setShowEmail] = useState(false);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleEmailAuth = async () => {
+    try {
+      await signIn(email, password);
+      onClose();
+    } catch (err) {
+      try {
+        await signUp(email, password);
+        onClose();
+      } catch (e) {
+        Alert.alert('Auth Error', e.message);
+      }
+    }
+  };
+
   return (
     <Modal visible={visible} animationType="slide" transparent>
       <View style={styles.overlay}>
@@ -23,35 +45,61 @@ const SignInModal = ({ visible, onClose }) => {
           {/* Title */}
           <Text style={styles.title}>Sign In</Text>
 
-          {/* Apple Sign In */}
-          <TouchableOpacity style={styles.appleButton} accessibilityRole="button" accessibilityLabel="Sign in with Apple">
-            <Ionicons name="logo-apple" size={20} color="#fff" />
-            <Text style={styles.appleButtonText}>Sign in with Apple</Text>
-          </TouchableOpacity>
+          {!showEmail ? (
+            <>
+              {/* Apple Sign In */}
+              <TouchableOpacity style={styles.appleButton} accessibilityRole="button" accessibilityLabel="Sign in with Apple">
+                <Ionicons name="logo-apple" size={20} color="#fff" />
+                <Text style={styles.appleButtonText}>Sign in with Apple</Text>
+              </TouchableOpacity>
 
-          {/* Google Sign In */}
-          <TouchableOpacity style={styles.googleButton} accessibilityRole="button" accessibilityLabel="Sign in with Google">
-            <Image source={require('../../assets/google-icon.png')} style={styles.icon} />
-            <Text style={styles.googleButtonText}>Sign in with Google</Text>
-          </TouchableOpacity>
+              {/* Google Sign In */}
+              <TouchableOpacity style={styles.googleButton} accessibilityRole="button" accessibilityLabel="Sign in with Google">
+                <Image source={require('../../assets/google-icon.png')} style={styles.icon} />
+                <Text style={styles.googleButtonText}>Sign in with Google</Text>
+              </TouchableOpacity>
 
-          {/* Email Sign In */}
-          <TouchableOpacity style={styles.emailButton} accessibilityRole="button" accessibilityLabel="Continue with email">
-            <Ionicons name="mail-outline" size={20} color="black" />
-            <Text style={styles.emailButtonText}>Continue with email</Text>
-          </TouchableOpacity>
+              {/* Email Sign In */}
+              <TouchableOpacity style={styles.emailButton} accessibilityRole="button" accessibilityLabel="Continue with email" onPress={() => setShowEmail(true)}>
+                <Ionicons name="mail-outline" size={20} color="black" />
+                <Text style={styles.emailButtonText}>Continue with email</Text>
+              </TouchableOpacity>
 
-          {/* Terms & Policy */}
-          <Text style={styles.terms}>
-            By continuing you agree to Cal AI's{' '}
-            <Text style={styles.link} onPress={() => Linking.openURL('https://yourapp.com/terms')}>
-              Terms and Conditions
-            </Text>{' '}
-            and{' '}
-            <Text style={styles.link} onPress={() => Linking.openURL('https://yourapp.com/privacy')}>
-              Privacy Policy
-            </Text>
-          </Text>
+              {/* Terms & Policy */}
+              <Text style={styles.terms}>
+                By continuing you agree to Cal AI's{' '}
+                <Text style={styles.link} onPress={() => Linking.openURL('https://yourapp.com/terms')}>
+                  Terms and Conditions
+                </Text>{' '}
+                and{' '}
+                <Text style={styles.link} onPress={() => Linking.openURL('https://yourapp.com/privacy')}>
+                  Privacy Policy
+                </Text>
+              </Text>
+            </>
+          ) : (
+            <>
+              <TextInput
+                style={styles.input}
+                placeholder="Email"
+                placeholderTextColor="#888"
+                keyboardType="email-address"
+                value={email}
+                onChangeText={setEmail}
+              />
+              <TextInput
+                style={styles.input}
+                placeholder="Password"
+                placeholderTextColor="#888"
+                secureTextEntry
+                value={password}
+                onChangeText={setPassword}
+              />
+              <TouchableOpacity style={styles.modalButton} onPress={handleEmailAuth} accessibilityRole="button" accessibilityLabel="Submit email">
+                <Text style={styles.modalButtonText}>Continue</Text>
+              </TouchableOpacity>
+            </>
+          )}
         </View>
       </View>
     </Modal>
@@ -134,6 +182,28 @@ const styles = StyleSheet.create({
     color: '#000',
     fontSize: 16,
     marginLeft: 8,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    width: '100%',
+    marginBottom: 12,
+  },
+  modalButton: {
+    backgroundColor: DARK_BLUE,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    width: '100%',
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  modalButtonText: {
+    color: '#fff',
+    fontSize: 16,
   },
   icon: {
     width: 20,

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'firebase/auth';
+import { auth } from '../../firebase';
+
+const AuthContext = createContext({
+  user: null,
+  signIn: async (email, password) => {},
+  signUp: async (email, password) => {},
+  signOutUser: async () => {},
+});
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, u => setUser(u));
+    return unsub;
+  }, []);
+
+  const signIn = useCallback((email, password) => signInWithEmailAndPassword(auth, email, password), []);
+
+  const signUp = useCallback((email, password) => createUserWithEmailAndPassword(auth, email, password), []);
+
+  const signOutUser = useCallback(() => signOut(auth), []);
+
+  return (
+    <AuthContext.Provider value={{ user, signIn, signUp, signOutUser }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -32,6 +32,8 @@ import EquipmentGrid from '../components/EquipmentGrid';
 import LevelUpModal from '../components/LevelUpModal';
 import NamePetModal from '../components/NamePetModal';
 import QuickWorkoutModal from '../components/QuickWorkoutModal';
+import SignInModal from '../components/SignInModal';
+import { useAuth } from '../context/AuthContext';
 import { useCharacter } from '../context/CharacterContext';
 import { CHARACTER_IMAGES } from '../data/characters';
 import { useBackground } from '../context/BackgroundContext';
@@ -146,6 +148,7 @@ export default function GymScreen() {
   const [showQuickWorkoutModal, setShowQuickWorkoutModal] = useState(false);
   const [tutorialStep, setTutorialStep] = useState(0);
   const [tutorialCompleted, setTutorialCompleted] = useState(false);
+  const [showAuthModal, setShowAuthModal] = useState(false);
   const arrowAnim = useRef(new Animated.Value(0)).current;
   const arrowLoop = useRef();
 
@@ -202,6 +205,7 @@ export default function GymScreen() {
   const sprite = CHARACTER_IMAGES[characterId] || CHARACTER_IMAGES.GorillaM;
   const { addWorkout, liftCount } = useStats();
   const { enabled: notificationsEnabled, recordLiftTime } = useNotifications();
+  const { user } = useAuth();
   const navigation = useNavigation();
   const [showStatsModal, setShowStatsModal] = useState(false);
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
@@ -545,15 +549,20 @@ const toggleWorkout = useCallback(() => {
         const firstLift = liftCount === 0;
         addWorkout(weight, true);
         recordLiftTime(now);
-        if (firstLift && !notificationsEnabled) {
-          Alert.alert(
-            'Enable Notifications',
-            `Turn on workout reminders in Settings so ${petName || 'your buddy'} can cheer you on.`,
-            [
-              { text: 'Later', style: 'cancel' },
-              { text: 'Open Settings', onPress: () => navigation.navigate('Settings') },
-            ]
-          );
+        if (firstLift) {
+          if (!notificationsEnabled) {
+            Alert.alert(
+              'Enable Notifications',
+              `Turn on workout reminders in Settings so ${petName || 'your buddy'} can cheer you on.`,
+              [
+                { text: 'Later', style: 'cancel' },
+                { text: 'Open Settings', onPress: () => navigation.navigate('Settings') },
+              ]
+            );
+          }
+          if (!user) {
+            setShowAuthModal(true);
+          }
         }
       }
       setSetCounts([]);
@@ -927,6 +936,7 @@ const toggleWorkout = useCallback(() => {
           </View>
         </View>
       </Modal>
+      <SignInModal visible={showAuthModal} onClose={() => setShowAuthModal(false)} />
     </SafeAreaView>
     </View>
     </ImageBackground>


### PR DESCRIPTION
## Summary
- finalize firebase initialization
- add new `AuthContext` with sign-in / sign-up helpers
- upgrade SignInModal with email auth support
- prompt user to sign in after their first lift
- wrap app in `AuthProvider`

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635f7576008328897521a75acce3cb