### PR TITLE
Adjust sign up and notification prompts

### DIFF
--- a/src/components/LevelUpModal.js
+++ b/src/components/LevelUpModal.js
@@ -1,15 +1,17 @@
-import React, { useEffect, useRef } from 'react';
-import { Modal, View, Text, StyleSheet, Animated } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal, View, Text, StyleSheet, Animated, TouchableWithoutFeedback } from 'react-native';
 import * as Progress from 'react-native-progress';
 
 const AnimatedBar = Animated.createAnimatedComponent(Progress.Bar);
 
 export default function LevelUpModal({ visible, onClose, petName }) {
   const progress = useRef(new Animated.Value(0)).current;
+  const [finished, setFinished] = useState(false);
 
   useEffect(() => {
     if (visible) {
       progress.setValue(0);
+      setFinished(false);
       Animated.sequence([
         Animated.timing(progress, {
           toValue: 1,
@@ -22,8 +24,8 @@ export default function LevelUpModal({ visible, onClose, petName }) {
           useNativeDriver: false,
         }),
       ]).start(({ finished }) => {
-        if (finished && onClose) {
-          onClose();
+        if (finished) {
+          setFinished(true);
         }
       });
     }
@@ -31,21 +33,28 @@ export default function LevelUpModal({ visible, onClose, petName }) {
 
   return (
     <Modal transparent visible={visible} animationType="fade">
-      <View style={styles.overlay}>
-        <View style={styles.box}>
-          <Text style={styles.text}>
-            {`Good Luck, ${petName || 'your pet'} is getting stronger!`}
-          </Text>
-          <AnimatedBar
-            progress={progress}
-            width={200}
-            height={12}
-            color="#4CAF50"
-            unfilledColor="#eee"
-            borderWidth={0}
-          />
+      <TouchableWithoutFeedback
+        onPress={() => {
+          if (finished && onClose) onClose();
+        }}
+      >
+        <View style={styles.overlay}>
+          <View style={styles.box}>
+            <Text style={styles.text}>
+              {`Good Luck, ${petName || 'your pet'} is getting stronger!`}
+            </Text>
+            <AnimatedBar
+              progress={progress}
+              width={200}
+              height={12}
+              color="#4CAF50"
+              unfilledColor="#eee"
+              borderWidth={0}
+            />
+            {finished && <Text style={styles.tapText}>Tap to continue</Text>}
+          </View>
         </View>
-      </View>
+      </TouchableWithoutFeedback>
     </Modal>
   );
 }
@@ -68,5 +77,10 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 16,
     color: '#222',
+  },
+  tapText: {
+    marginTop: 12,
+    color: '#555',
+    fontSize: 14,
   },
 });


### PR DESCRIPTION
## Summary
- allow dismissing the level-up modal and show hint to tap
- ask to sign in after dismissing the level-up modal
- move notification prompt to first profile visit

## Testing
- `npm start -- --help` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863633fe95c8328857eab4b8bd41238