### PR TITLE
Enforce sign-in requirement

### DIFF
--- a/src/components/SignInModal.js
+++ b/src/components/SignInModal.js
@@ -34,14 +34,14 @@ const SignInModal = ({ visible, onClose }) => {
   };
 
   return (
-    <Modal visible={visible} animationType="slide" transparent>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={() => {}}
+    >
       <View style={styles.overlay}>
         <View style={styles.modal}>
-          {/* Close Button */}
-          <TouchableOpacity style={styles.closeButton} onPress={onClose} accessibilityRole="button" accessibilityLabel="Close sign in">
-            <Ionicons name="close" size={24} color="black" />
-          </TouchableOpacity>
-
           {/* Title */}
           <Text style={styles.title}>Sign In</Text>
 
@@ -120,11 +120,6 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,
     alignItems: 'center',
-  },
-  closeButton: {
-    position: 'absolute',
-    top: 16,
-    right: 16,
   },
   title: {
     fontSize: 22,


### PR DESCRIPTION
## Summary
- remove close button from `SignInModal`
- disable the hardware back button on the sign-in modal so it can't be dismissed

## Testing
- `npm start` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863674b373483288d561efa4c3e9687