### PR TITLE
Fix auth prompt variable reference

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -537,6 +537,7 @@ const toggleWorkout = useCallback(() => {
   setTutorialStep(0);
   setWorkoutActive(active => {
     const next = !active;
+    let shouldPromptAuth = false;
     if (active && !next) {
       const totalSets = setCounts.reduce((sum, c) => sum + c, 0);
       if (totalSets > 0) {
@@ -558,7 +559,7 @@ const toggleWorkout = useCallback(() => {
         const firstLift = liftCount === 0;
         addWorkout(weight, true);
         recordLiftTime(now);
-        const shouldPromptAuth = firstLift && !user;
+        shouldPromptAuth = firstLift && !user;
         if (shouldPromptAuth) {
           setPendingAuthPrompt(true);
         }


### PR DESCRIPTION
## Summary
- ensure `shouldPromptAuth` is defined even when no sets were logged

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686367dee418832880c08a26f6839f72