### PR TITLE
Fix workout toggle conditional

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -579,7 +579,7 @@ setWorkoutActive(active => {
   return next;
 });
 
-
+  if (workoutActive) {
     setSetCounts([]);
     setWorkoutActive(false);
 


### PR DESCRIPTION
## Summary
- fix missing workoutActive check when toggling workouts

## Testing
- `npm start -- --help` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863707eef008328bade4a6b9635dbdb