### PR TITLE
Fix auth prompt flag in GymScreen

### DIFF
--- a/src/screens/GymScreen.js
+++ b/src/screens/GymScreen.js
@@ -535,6 +535,7 @@ const toggleWorkout = useCallback(() => {
     setTutorialCompleted(true);
   }
   setTutorialStep(0);
+  const shouldPromptAuth = liftCount === 0 && !user;
 setWorkoutActive(active => {
   const next = !active;
   if (active && !next) {
@@ -555,9 +556,6 @@ setWorkoutActive(active => {
         const w = parseFloat(ex.weight) || 0;
         weight += setsDone * reps * w;
       });
-
-      const firstLift = liftCount === 0;
-      const shouldPromptAuth = firstLift && !user;
 
       addWorkout(weight, true);
       recordLiftTime(now);


### PR DESCRIPTION
## Summary
- fix reference error in `toggleWorkout` by moving `shouldPromptAuth` outside the state update

## Testing
- `npm start` *(fails: expo not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864688a91cc832891130b0400fb1332