### PR TITLE
Enable Google and Apple login

### DIFF
--- a/src/components/SignInModal.js
+++ b/src/components/SignInModal.js
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useAuth } from '../context/AuthContext';
 
 const SignInModal = ({ visible, onClose }) => {
-  const { signIn, signUp } = useAuth();
+  const { signIn, signUp, signInWithGoogle, signInWithApple } = useAuth();
   const [showEmail, setShowEmail] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -48,13 +48,23 @@ const SignInModal = ({ visible, onClose }) => {
           {!showEmail ? (
             <>
               {/* Apple Sign In */}
-              <TouchableOpacity style={styles.appleButton} accessibilityRole="button" accessibilityLabel="Sign in with Apple">
+              <TouchableOpacity
+                style={styles.appleButton}
+                accessibilityRole="button"
+                accessibilityLabel="Sign in with Apple"
+                onPress={signInWithApple}
+              >
                 <Ionicons name="logo-apple" size={20} color="#fff" />
                 <Text style={styles.appleButtonText}>Sign in with Apple</Text>
               </TouchableOpacity>
 
               {/* Google Sign In */}
-              <TouchableOpacity style={styles.googleButton} accessibilityRole="button" accessibilityLabel="Sign in with Google">
+              <TouchableOpacity
+                style={styles.googleButton}
+                accessibilityRole="button"
+                accessibilityLabel="Sign in with Google"
+                onPress={signInWithGoogle}
+              >
                 <Image source={require('../../assets/google-icon.png')} style={styles.icon} />
                 <Text style={styles.googleButtonText}>Sign in with Google</Text>
               </TouchableOpacity>

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -1,30 +1,115 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
-import { onAuthStateChanged, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut } from 'firebase/auth';
-import { auth } from '../../firebase';
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  signInWithCredential,
+  GoogleAuthProvider,
+  OAuthProvider,
+} from 'firebase/auth';
+import { doc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { auth, db } from '../../firebase';
+import * as Google from 'expo-auth-session/providers/google';
+import * as AppleAuthentication from 'expo-apple-authentication';
 
 const AuthContext = createContext({
   user: null,
   signIn: async (email, password) => {},
   signUp: async (email, password) => {},
   signOutUser: async () => {},
+  signInWithGoogle: async () => {},
+  signInWithApple: async () => {},
 });
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
+  const [googleRequest, googleResponse, promptGoogle] = Google.useIdTokenAuthRequest({
+    clientId: 'YOUR_GOOGLE_CLIENT_ID',
+  });
 
   useEffect(() => {
     const unsub = onAuthStateChanged(auth, u => setUser(u));
     return unsub;
   }, []);
 
-  const signIn = useCallback((email, password) => signInWithEmailAndPassword(auth, email, password), []);
+  useEffect(() => {
+    (async () => {
+      if (googleResponse?.type === 'success') {
+        try {
+          const { id_token } = googleResponse.params;
+          const credential = GoogleAuthProvider.credential(id_token);
+          const cred = await signInWithCredential(auth, credential);
+          await saveUserData(cred.user);
+        } catch (e) {
+          console.log('Google sign in error', e);
+        }
+      }
+    })();
+  }, [googleResponse, saveUserData]);
 
-  const signUp = useCallback((email, password) => createUserWithEmailAndPassword(auth, email, password), []);
+  const saveUserData = useCallback(async user => {
+    if (!user) return;
+    await setDoc(
+      doc(db, 'users', user.uid),
+      {
+        email: user.email,
+        displayName: user.displayName || '',
+        createdAt: serverTimestamp(),
+      },
+      { merge: true }
+    );
+  }, []);
+
+  const signIn = useCallback(async (email, password) => {
+    const cred = await signInWithEmailAndPassword(auth, email, password);
+    await saveUserData(cred.user);
+    return cred;
+  }, [saveUserData]);
+
+  const signUp = useCallback(async (email, password) => {
+    const cred = await createUserWithEmailAndPassword(auth, email, password);
+    await saveUserData(cred.user);
+    return cred;
+  }, [saveUserData]);
 
   const signOutUser = useCallback(() => signOut(auth), []);
 
+  const signInWithGoogle = useCallback(async () => {
+    await promptGoogle();
+  }, [promptGoogle]);
+
+  const signInWithApple = useCallback(async () => {
+    try {
+      const appleAuth = await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+        ],
+      });
+      if (!appleAuth.identityToken) return;
+      const provider = new OAuthProvider('apple.com');
+      const credential = provider.credential({ idToken: appleAuth.identityToken });
+      const cred = await signInWithCredential(auth, credential);
+      await saveUserData(cred.user);
+    } catch (e) {
+      if (e.code !== 'ERR_CANCELED') {
+        console.log('Apple sign in error', e);
+      }
+    }
+  }, [saveUserData]);
+
   return (
-    <AuthContext.Provider value={{ user, signIn, signUp, signOutUser }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        signIn,
+        signUp,
+        signOutUser,
+        signInWithGoogle,
+        signInWithApple,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- extend AuthContext with Google/Apple login helpers
- persist user data in Firestore on login
- wire SignInModal buttons to new auth methods

## Testing
- `npm install`
- `npm start` *(fails: waiting for metro server to be accessible but no errors)*

------
https://chatgpt.com/codex/tasks/task_e_68646d1f00bc8328a4692d620808068c