### PR TITLE
Add expo-apple-authentication dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/native-stack": "^7.3.16",
         "bad-words": "^4.0.0",
         "expo": "~53.0.11",
+        "expo-apple-authentication": "^7.2.4",
         "expo-av": "^15.1.6",
         "expo-image-picker": "^16.1.4",
         "expo-notifications": "^0.20.1",
@@ -5463,6 +5464,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-7.2.4.tgz",
+      "integrity": "sha512-T2agaLLPT4Ax97FeXImB7BCCEzEJ0gB+ZwlFa/FXBtbp6WFKcGRlTVKiX2YPYLZzN5QjXcmQ9HHJ17jRthNHMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "^4.11.1",
     "react-native-tab-view": "^3.5.2",
-    "react-native-wheel-picker-expo": "^0.5.4"
+    "react-native-wheel-picker-expo": "^0.5.4",
+    "expo-apple-authentication": "^7.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- add expo-apple-authentication to dependencies
- regenerate package-lock

## Testing
- `npm install --package-lock-only`
- `npm install --silent`
- `npx expo start --no-dev --minify` *(server started then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_686470fca9f48328bb953bbe3f9bda81